### PR TITLE
[FEAT] (FE) Header 컴포넌트 추가

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/frontend/src/components/common/LogoLink.tsx
+++ b/frontend/src/components/common/LogoLink.tsx
@@ -1,0 +1,15 @@
+import { Link } from 'react-router-dom'
+
+import { routes } from '@/routes'
+
+function LogoLink() {
+  return (
+    <Link to={routes.plans}>
+      <h1 className="font-logo text-2xl text-primary-default">
+        Travel Manager
+      </h1>
+    </Link>
+  )
+}
+
+export default LogoLink

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,25 @@
+import { useMemo } from 'react'
+import { FiPlusSquare } from 'react-icons/fi'
+import { Link, useLocation } from 'react-router-dom'
+
+import { routes } from '@/routes'
+
+import LogoLink from '../common/LogoLink'
+
+function Header() {
+  const { pathname } = useLocation()
+  const isAddPlanPage = useMemo(() => pathname === routes.addPlan, [pathname])
+
+  return (
+    <header className="mb-4 flex items-center justify-between p-4 shadow-bottom">
+      <LogoLink />
+      {!isAddPlanPage && (
+        <Link to={routes.addPlan}>
+          <FiPlusSquare size="24px" color="var(--gray-400)" />
+        </Link>
+      )}
+    </header>
+  )
+}
+
+export default Header

--- a/frontend/src/components/layout/index.tsx
+++ b/frontend/src/components/layout/index.tsx
@@ -1,16 +1,26 @@
-import React from 'react'
+import React, { useMemo } from 'react'
+import { useLocation } from 'react-router-dom'
+
+import { routes } from '@/routes'
 
 import LogoSection from '../common/LogoSection'
+import Header from './Header'
 
 type Props = {
   children: React.ReactNode
 }
 
 function Layout({ children }: Props) {
+  const { pathname } = useLocation()
+  const isLoginPage = useMemo(() => pathname === routes.login, [pathname])
+
   return (
     <div className="layout">
       <LogoSection />
-      <div className="container shadow-container">{children}</div>
+      <div className="container shadow-container">
+        {!isLoginPage && <Header />}
+        {children}
+      </div>
     </div>
   )
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -40,6 +40,7 @@ export default {
       },
       boxShadow: {
         container: '0px 0px 16px rgb(50 50 50 / 12%)',
+        bottom: '0px 0px 16px 0px rgb(50 50 50 / 12%)',
       },
     },
   },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2575,6 +2575,11 @@ react-dom@^18.3.1:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
+react-icons@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.3.0.tgz#ccad07a30aebd40a89f8cfa7d82e466019203f1c"
+  integrity sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## ✅ ISSUE 번호
#16 

## ✅ 작업 내용
- Header 컴포넌트 추가
    ![스크린샷 2024-08-16 오후 11 36 47](https://github.com/user-attachments/assets/637948f5-0695-4225-945a-d6cc130fba34)

   - 로그인 페이지를 제외한 모든 페이지에 Header 추가
   - 메인, 여행 상세&수정 페이지에 여행 생성 버튼 추가
- `react-icons` 설치

## ✅ 리뷰 요청사항
