### PR TITLE
[FEAT] (FE) 카테고리 버튼 컴포넌트 구현

### DIFF
--- a/frontend/src/components/common/CategoryList.tsx
+++ b/frontend/src/components/common/CategoryList.tsx
@@ -1,41 +1,39 @@
+type Props = {
+  name: string
+  color: string
+}
+
 type CategoryType = {
   name: string
   color: string
 }
 
-type Props = {
-  category: CategoryType
+const CategoryItemButton = ({ name, color }: Props) => {
+  const categoryItemStyleClass = `mx-1 rounded-lg px-2 py-2 font-sans text-xs bg-${color}`
+
+  return <button className={categoryItemStyleClass}>{name}</button>
 }
 
-const CategoryButton = ({ category }: Props) => {
-  const { name, color } = category
-
-  return (
-    <button
-      className="mx-1 rounded-lg px-2 py-2 font-sans text-xs"
-      style={{ backgroundColor: color }}
-    >
-      {name}
-    </button>
-  )
-}
+const categories: CategoryType[] = [
+  { name: '활동', color: 'blue-300' },
+  { name: '숙소', color: 'violet-300' },
+  { name: '아침', color: 'teal-300' },
+  { name: '점심', color: 'yellow-200' },
+  { name: '저녁', color: 'indigo-300' },
+  { name: '카페', color: 'stone-400' },
+]
 
 const CategoryList = () => {
-  const categories: CategoryType[] = [
-    { name: '활동', color: '#A9C6F1' },
-    { name: '숙소', color: '#90BA8A' },
-    { name: '아침', color: '#A3D4CC' },
-    { name: '점심', color: '#FEE2E2' },
-    { name: '저녁', color: '#FEF08A' },
-    { name: '카페', color: '#D9D9D9' },
-  ]
-
   return (
-    <div className="flex items-center space-x-4">
+    <div className="my-3 flex items-center space-x-4">
       <span className="font-sans text-xs">카테고리</span>
       <div>
         {categories.map((category, index) => (
-          <CategoryButton key={index} category={category} />
+          <CategoryItemButton
+            key={index}
+            name={category.name}
+            color={category.color}
+          />
         ))}
       </div>
     </div>

--- a/frontend/src/components/common/CategoryList.tsx
+++ b/frontend/src/components/common/CategoryList.tsx
@@ -1,0 +1,45 @@
+type CategoryType = {
+  name: string
+  color: string
+}
+
+type Props = {
+  category: CategoryType
+}
+
+const CategoryButton = ({ category }: Props) => {
+  const { name, color } = category
+
+  return (
+    <button
+      className="mx-1 rounded-lg px-2 py-2 font-sans text-xs"
+      style={{ backgroundColor: color }}
+    >
+      {name}
+    </button>
+  )
+}
+
+const CategoryList = () => {
+  const categories: CategoryType[] = [
+    { name: '활동', color: '#A9C6F1' },
+    { name: '숙소', color: '#90BA8A' },
+    { name: '아침', color: '#A3D4CC' },
+    { name: '점심', color: '#FEE2E2' },
+    { name: '저녁', color: '#FEF08A' },
+    { name: '카페', color: '#D9D9D9' },
+  ]
+
+  return (
+    <div className="flex items-center space-x-4">
+      <span className="font-sans text-xs">카테고리</span>
+      <div>
+        {categories.map((category, index) => (
+          <CategoryButton key={index} category={category} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default CategoryList

--- a/frontend/src/pages/PlanDetailPage.tsx
+++ b/frontend/src/pages/PlanDetailPage.tsx
@@ -1,5 +1,12 @@
+import CategoryList from '@/components/common/CategoryList'
+
 function PlanDetailPage() {
-  return <div>Plan Detail Page</div>
+  return (
+    <div>
+      <div>Plan Detail Page</div>
+      <CategoryList />
+    </div>
+  )
 }
 
 export default PlanDetailPage


### PR DESCRIPTION
## ✅ ISSUE 번호
#21 
## ✅ 작업 내용
![image](https://github.com/user-attachments/assets/5f9071b3-de82-4a0a-a94e-76fbcf8bee6f)
- 여행 계획 카테고리 선택을 위한 버튼 컴포넌트 구현했습니다. 
## ✅ 리뷰 요청사항
