### PR TITLE
[FEAT] (FE) '/plans' 페이지 구현

### DIFF
--- a/frontend/src/api/plans.api.ts
+++ b/frontend/src/api/plans.api.ts
@@ -1,0 +1,13 @@
+import axios from 'axios'
+
+import { Plan } from '@/models/plan.model'
+
+export const fetchPlans = async (): Promise<Plan[]> => {
+  try {
+    const response = await axios.get<Plan[]>('http://localhost:3000/plans')
+    return response.data
+  } catch (error) {
+    console.error('Error fetching plans:', error)
+    return []
+  }
+}

--- a/frontend/src/models/plan.model.ts
+++ b/frontend/src/models/plan.model.ts
@@ -1,0 +1,10 @@
+export type Plan = {
+  id: string
+  plan_name: string
+  plan_country: string
+  start_date: string
+  end_date: string
+  head_count: number
+  total_expenses: number
+  plan_end: boolean
+}

--- a/frontend/src/pages/PlanListPage.tsx
+++ b/frontend/src/pages/PlanListPage.tsx
@@ -1,5 +1,67 @@
+import { useEffect, useState } from 'react'
+import { BiMoneyWithdraw } from 'react-icons/bi'
+import { BsPeopleFill } from 'react-icons/bs'
+import { GiAirplaneArrival, GiAirplaneDeparture } from 'react-icons/gi'
+import { PiMapPinAreaBold } from 'react-icons/pi'
+import { Link } from 'react-router-dom'
+
+import { fetchPlans } from '@/api/plans.api'
+import { Plan } from '@/models/plan.model'
+import { routes } from '@/routes'
+import { formatDate, formatNumber } from '@/utils/format'
+
 function PlanListPage() {
-  return <div>Plan List Page</div>
+  const [plans, setPlans] = useState<Plan[]>([])
+
+  useEffect(() => {
+    const getPlans = async () => {
+      const plansData = await fetchPlans()
+      setPlans(plansData)
+    }
+
+    getPlans()
+  }, [])
+
+  return (
+    <div className="h-screen items-center justify-center">
+      <ul className="w-full max-w-3xl space-y-4">
+        {plans.map((plan) => (
+          <li
+            key={plan.id}
+            className="mx-2 mt-3 rounded-2xl bg-primary-50 p-4 text-base shadow-lg lg:text-sm"
+          >
+            <Link to={routes.plan}>
+              <h2 className="mb-2 text-xl font-semibold lg:text-lg">
+                {plan.plan_name}
+              </h2>
+              <div className="flex justify-between">
+                <div className="flex items-center space-x-2">
+                  <GiAirplaneDeparture size="20" color="#96948f" />
+                  <p>출발일 : {formatDate(plan.start_date)}</p>
+                </div>
+
+                <div className="flex items-center space-x-2">
+                  <GiAirplaneArrival size="20" color="#96948f" />
+                  <p>도착일 : {formatDate(plan.end_date)}</p>
+                </div>
+              </div>
+              <div className="flex items-center space-x-2">
+                <PiMapPinAreaBold size="18" color="#f00" />{' '}
+                <p>여행지 : {plan.plan_country}</p>
+              </div>
+              <div className="flex items-center space-x-2">
+                <BsPeopleFill size="18" /> <p>인원 : {plan.head_count}명</p>
+              </div>
+              <div className="mt-2 flex items-center justify-end space-x-2">
+                <BiMoneyWithdraw size="20" color="#a88b42" />{' '}
+                <p>예상 경비 : {formatNumber(plan.total_expenses)}원</p>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
 }
 
 export default PlanListPage

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,9 @@
+import dayjs from 'dayjs'
+
+export const formatNumber = (number: number): string => {
+  return number.toLocaleString()
+}
+
+export const formatDate = (date: string, format?: string) => {
+  return dayjs(date).format(format ? format : 'YYYY년 MM월 DD일')
+}


### PR DESCRIPTION
## ✅ ISSUE 번호
#19 
## ✅ 작업 내용
### '/plans' 페이지 구현
- plan container 생성
- plans 데이터 백으로부터 가져오기
- 화면 크기마다 글씨체 다르게 설정
![image](https://github.com/user-attachments/assets/708da2b9-311f-4051-9891-29fea6a3867f)
![image](https://github.com/user-attachments/assets/67f3859e-8c49-4884-90a4-95734ba168a0)

## ✅ 리뷰 요청사항
