### PR TITLE
[FEAT] (FE) 여행 정보 확인 단계 추가

### DIFF
--- a/frontend/src/components/addPlan/CheckPlan.tsx
+++ b/frontend/src/components/addPlan/CheckPlan.tsx
@@ -1,5 +1,44 @@
+import { usePlanStore } from '@/store/plan'
+import { DateFormatTypeEnum } from '@/types'
+import { formatDate } from '@/utils/formatDate'
+
+import { Field } from '../common'
+
 function CheckPlan() {
-  return <></>
+  const {
+    plan: { name, headCount, startDate, endDate, places },
+  } = usePlanStore()
+
+  return (
+    <div className="mt-3 flex flex-col gap-y-2 px-2">
+      <Field name="여행명" value={name} />
+      <Field name="총인원" value={`${headCount}명`} />
+      <Field
+        name="출발일"
+        value={formatDate(DateFormatTypeEnum.DateWithSlash, startDate)}
+      />
+      <Field
+        name="도착일"
+        value={formatDate(DateFormatTypeEnum.DateWithSlash, endDate)}
+      />
+      <Field
+        name="여행지"
+        value={
+          <div className="flex flex-col gap-y-2">
+            {places.map((elem) => (
+              <div key={elem.id} className="flex gap-x-3">
+                <span className="text-nowrap">{elem.place}</span>
+                <p className="text-gray-500">
+                  {formatDate(DateFormatTypeEnum.DateWithSlash, elem.startDate)}{' '}
+                  - {formatDate(DateFormatTypeEnum.DateWithSlash, elem.endDate)}
+                </p>
+              </div>
+            ))}
+          </div>
+        }
+      />
+    </div>
+  )
 }
 
 export default CheckPlan

--- a/frontend/src/components/addPlan/MoveStepButtons/index.tsx
+++ b/frontend/src/components/addPlan/MoveStepButtons/index.tsx
@@ -20,6 +20,11 @@ function MoveStepButtons({ stepIndex, isValid, moveStep }: Props) {
     moveStep(stepIndex - 1)
   }
   const moveToNextStep = () => {
+    if (isLastStep) {
+      // TODO: api call
+      return
+    }
+
     moveStep(stepIndex + 1)
   }
 

--- a/frontend/src/components/common/Field.tsx
+++ b/frontend/src/components/common/Field.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+type Props = {
+  name: string
+  value: React.ReactNode | string
+}
+
+function Field({ name, value }: Props) {
+  return (
+    <div className="flex w-full gap-x-4 py-2">
+      <span className="inline-block min-w-20 text-nowrap text-gray-500">
+        {name}
+      </span>
+
+      <div className="w-full">
+        {typeof value === 'string' ? (
+          <p className="text-gray-700">{value}</p>
+        ) : (
+          <>{value}</>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default Field

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -1,5 +1,6 @@
 export { default as Button } from './Button'
 export { default as DateRangePicker } from './DateRangePicker'
+export { default as Field } from './Field'
 export { default as Input } from './Input'
 export { default as LoadingSpinner } from './LoadingSpinner'
 export { default as LogoLink } from './LogoLink'

--- a/frontend/src/pages/AddPlanPage.tsx
+++ b/frontend/src/pages/AddPlanPage.tsx
@@ -28,9 +28,15 @@ function AddPlanPage() {
       case AddPlanStepEnum.SetInfo:
         return !errors.name && !errors.headCount
       case AddPlanStepEnum.SetPlaceAndDate:
-        return !!plan.startDate && !!plan.endDate && plan.places.length > 0
+        return (
+          !!plan.startDate &&
+          !!plan.endDate &&
+          plan.places.length > 0 &&
+          plan.places.filter((elem) => !elem.startDate || !elem.endDate)
+            .length === 0
+        )
       case AddPlanStepEnum.CheckPlan:
-        return !errors.places
+        return true
     }
   }, [currentStep, plan, errors])
   const moveStep = (step: number) => {


### PR DESCRIPTION
## ✅ ISSUE 번호
#56 

## ✅ 작업 내용
<img width="430" alt="스크린샷 2024-08-22 오후 12 54 41" src="https://github.com/user-attachments/assets/b21c63e9-3ba5-4d61-a724-23836ece3e95">

- url: `/add-plan`
- 여행 정보 확인 단계 ui 작업
- 공통 `Field` 컴포넌트 추가
   ```tsx
       <Field
        name="도착일"
        value={formatDate(DateFormatTypeEnum.DateWithSlash, endDate)}
      />
   ```

## ✅ 리뷰 요청사항
