### PR TITLE
[FEAT] (BE) : plans sorting 기능 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -34,7 +34,7 @@ import { Plan } from './modules/plan/entities/plan.entity';
       charset: 'utf8mb4_general_ci',
       synchronize: false,
       logging: process.env.NODE_ENV === 'development',
-      migrations: [__dirname + '/migrations/**/*{.ts,.js}'],
+      migrations: [__dirname + '/migrations/**/*{.ts,.js}']
     }),
     JwtModule.register({
       global: true,

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -32,7 +32,7 @@ import { Plan } from './modules/plan/entities/plan.entity';
       database: process.env.DB_DATABASE,
       entities: [Users, Plan],
       charset: 'utf8mb4_general_ci',
-      synchronize: process.env.NODE_ENV === 'development',
+      synchronize: false,
       logging: process.env.NODE_ENV === 'development',
       migrations: [__dirname + '/migrations/**/*{.ts,.js}'],
     }),

--- a/backend/src/modules/plan/plan.service.ts
+++ b/backend/src/modules/plan/plan.service.ts
@@ -17,7 +17,12 @@ export class PlanService {
   }
 
   async findAll(): Promise<Plan[]> {
-    return this.planRepository.find();
+    return this.planRepository.find({
+      order: {
+        plan_end: 'ASC',
+        start_date:'ASC'
+      }
+    });
   }
 
   findOne(id: number) {

--- a/backend/src/modules/plan/plan.service.ts
+++ b/backend/src/modules/plan/plan.service.ts
@@ -20,8 +20,8 @@ export class PlanService {
     return this.planRepository.find({
       order: {
         plan_end: 'ASC',
-        start_date:'ASC'
-      }
+        start_date: 'ASC',
+      },
     });
   }
 


### PR DESCRIPTION
## ✅ ISSUE 번호
#58 
## ✅ 작업 내용
- plan_end false인 plan을 앞쪽으로
- 그 다음 start_date로 sorting
<img width="363" alt="image" src="https://github.com/user-attachments/assets/03abf9ce-60e9-473a-b720-b1c6a6f7898d">

## ✅ 리뷰 요청사항
