### PR TITLE
[FIX] (FE/BE) 로그인 API 변경에 따른 CORS 및 카카오 연동 로그인 버그 해결

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -9,6 +9,7 @@ import {
   HttpCode,
   UnauthorizedException,
   Res,
+  Query,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { ConfigService } from '@nestjs/config';

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -76,6 +76,7 @@ export class AuthController {
   // @UseGuards(AuthGuard('kakao'))
   @HttpCode(HttpStatus.OK)
   async kakaoLogin(@Body() body: { kakaoAccessToken: string }) {
+    console.log('카카오 요청바디', body);
     try {
       const { user, accessToken, refreshToken } =
         await this.authService.loginWithKakao(body.kakaoAccessToken);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,10 +6,8 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 declare const module: any;
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, { cors: true });
-  app.enableCors({
-    origin: ['http://localhost:5173'],
-  });
+  const app = await NestFactory.create(AppModule);
+  app.enableCors();
 
   const port = process.env.PORT;
   app.useGlobalPipes(
@@ -28,7 +26,6 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
 
-  app.enableCors();
   await app.listen(port);
 
   console.log(

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,11 +6,8 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 declare const module: any;
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  app.enableCors({
-    origin: 'http://localhost:5173',
-    credentials: true,
-  });
+  const app = await NestFactory.create(AppModule, { cors: true });
+
   const port = process.env.PORT;
   app.useGlobalPipes(
     new ValidationPipe({

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -7,6 +7,9 @@ declare const module: any;
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { cors: true });
+  app.enableCors({
+    origin: ['http://localhost:5173'],
+  });
 
   const port = process.env.PORT;
   app.useGlobalPipes(

--- a/frontend/src/api/kakaoAuth.ts
+++ b/frontend/src/api/kakaoAuth.ts
@@ -2,14 +2,19 @@ import { IKakaoUserSuccess } from '@/types/kakao'
 
 import { axiosRequestHandler } from './http'
 
+interface IGetKakaoTokenBody {
+  kakaoAccessToken: string
+}
+
 export const getKakaoToken = async ({ code }: { code: string }) => {
   // const response = await httpClient.get<IKakaoUserSuccess>(
   //   `/api/auth/kakao?code=${code}`
   // )
   // return response.data
 
-  return axiosRequestHandler<IKakaoUserSuccess>({
-    method: 'get',
-    url: `/api/auth/kakao?code=${code}`,
+  return axiosRequestHandler<IKakaoUserSuccess, IGetKakaoTokenBody>({
+    method: 'post',
+    url: `/api/auth/kakao`,
+    data: { kakaoAccessToken: code },
   })
 }

--- a/frontend/src/api/setting.ts
+++ b/frontend/src/api/setting.ts
@@ -36,7 +36,7 @@ export const createClient = (config?: AxiosRequestConfig): AxiosInstance => {
       'Content-Type': 'application/json',
       Authorization: getToken('accessToken') ? getToken('accessToken') : '',
     },
-    withCredentials: true,
+
     ...config,
   })
 

--- a/frontend/src/hooks/useKakaoLogin.ts
+++ b/frontend/src/hooks/useKakaoLogin.ts
@@ -16,6 +16,7 @@ export const useKakaoLogin = ({ code }: Props) => {
   useEffect(() => {
     getKakaoToken({ code })
       .then((response) => {
+        console.log(response)
         if (response?.data?.accessToken && response?.data?.refreshToken) {
           authLogin('accessToken', response.data.accessToken)
           setToken('refreshToken', response.data.refreshToken)

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
+  // <StrictMode>
+  //   <App />
+  // </StrictMode>
+  <App />
 )

--- a/frontend/src/pages/KakaoLoginPage.tsx
+++ b/frontend/src/pages/KakaoLoginPage.tsx
@@ -7,7 +7,7 @@ import { useKakaoLogin } from '@/hooks/useKakaoLogin'
 
 function KakaoLoginPage() {
   const code = new URL(window.location.href).searchParams.get('code')!
-
+  console.log(code)
   useKakaoLogin({ code })
 
   return (

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -18,7 +18,7 @@ export function getToken(tokenName: TTokenName) {
 }
 
 export function setToken(tokenName: TTokenName, tokenValue: string) {
-  localStorage.setItem(tokenValue, tokenName)
+  localStorage.setItem(tokenName, tokenValue)
 }
 
 export function removeToken(tokenName: TTokenName) {


### PR DESCRIPTION
## ✅ ISSUE 번호

## ✅ 작업 내용
기존 Kakao Endpoint를 사용하기 위한 토큰 A 와 Kakao Endpoint 를 통해 발급 받게 되는 토큰 B로 카카오 인증을 진행하던
Flow에서, A토큰만 사용하게 되는 flow 로 백엔드 구조가 변경 되었었는데,
해당 flow를 다시 kakao Endnpoint를 통해야 발급 받을 수 있는 B 토큰 사용 방식으로 변경하였습니다.

또한 kakao login 인을 위한 API Method 변경 (GET -> POST) 으로 인해,
FE측 src/api/kakaoAuth.ts 의 getKakaoToken 함수의 요청 방식 또한 변경 및 적용 하였습니다.



## ✅ 리뷰 요청사항
