### PR TITLE
[FEAT] (FE) : '/plans' page UI 개선

### DIFF
--- a/frontend/src/components/addPlan/PlanInfo.tsx
+++ b/frontend/src/components/addPlan/PlanInfo.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+type PlanInfoProps = {
+  icon: React.ReactNode
+  title: string
+  content: string
+}
+
+export const PlanInfo: React.FC<PlanInfoProps> = ({ icon, title, content }) => {
+  return (
+    <div className="mb-1 flex items-center justify-between space-x-2">
+      <div className="flex space-x-2">
+        {icon}
+        <p className="font-semibold">{title}</p>
+      </div>
+      <p>{content}</p>
+    </div>
+  )
+}

--- a/frontend/src/pages/PlanListPage.tsx
+++ b/frontend/src/pages/PlanListPage.tsx
@@ -8,6 +8,7 @@ import { RiArrowRightDoubleFill } from 'react-icons/ri'
 import { Link } from 'react-router-dom'
 
 import { fetchPlans } from '@/api/plans.api'
+import { PlanInfo } from '@/components/addPlan/PlanInfo'
 import { Plan } from '@/models/plan.model'
 import { routes } from '@/routes'
 import { formatDate, formatNumber } from '@/utils/format'
@@ -24,13 +25,13 @@ function PlanListPage() {
 
   const handleNextPage = () => {
     if (currentPage < totalPages) {
-      setCurrentPage(currentPage + 1)
+      setCurrentPage((prevPage) => prevPage + 1)
     }
   }
 
   const handlePrevPage = () => {
     if (currentPage > 1) {
-      setCurrentPage(currentPage - 1)
+      setCurrentPage((prevPage) => prevPage - 1)
     }
   }
 
@@ -51,45 +52,48 @@ function PlanListPage() {
           <div key={plan.id}>
             {index > 0 &&
               plan.plan_end !== currentPlans[index - 1].plan_end && (
-                <hr className="mx-4 my-4 border-t-2 border-dotted border-gray-400" />
+                <hr className="mx-4 my-1.5 border-t-2 border-dotted border-gray-400" />
               )}
             <li
-              className={`mx-4 rounded-2xl p-4 text-sm shadow-lg ${
+              className={`relative mx-4 rounded-2xl p-4 text-sm shadow-lg ${
                 plan.plan_end ? 'bg-gray-300' : 'bg-primary-50'
               }`}
             >
+              {plan.plan_end && (
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <span className="pointer-events-none rotate-12 transform text-4xl font-bold uppercase text-red-500 opacity-60">
+                    END
+                  </span>
+                </div>
+              )}
               <Link to={routes.plan}>
-                <h2 className="mb-1.5 text-xl font-semibold lg:text-lg">
+                <h2 className="mb-1.5 text-base font-semibold">
                   {plan.plan_name}
                 </h2>
                 <div className="flex justify-between">
-                  <div className="mb-1 flex items-center space-x-2">
+                  <div className="mb-1.5 flex items-center space-x-2">
                     <GiAirplaneDeparture size="20" color="#96948f" />
                     <p>{formatDate(plan.start_date)}</p>
                   </div>
-                  <div className="mb-1 flex items-center">
+                  <div className="mb-1.5 flex items-center">
                     <RiArrowRightDoubleFill size="20" />
                   </div>
-                  <div className="mb-1 flex items-center space-x-2">
+                  <div className="mb-1.5 flex items-center space-x-2">
                     <GiAirplaneArrival size="20" color="#96948f" />
                     <p>{formatDate(plan.end_date)}</p>
                   </div>
                 </div>
-                <div className="mb-1 flex items-center justify-between space-x-2">
-                  <div className="flex space-x-2">
-                    <PiMapPinAreaBold size="18" color="#f00" />
-                    <p className="font-semibold">여행지</p>
-                  </div>
-                  <p>{plan.plan_country}</p>
-                </div>
-                <div className="mb-1 flex items-center justify-between space-x-2">
-                  <div className="flex space-x-2">
-                    <BsPeopleFill size="18" />
-                    <p className="font-semibold">인원</p>
-                  </div>
-                  <p>{plan.head_count}명</p>
-                </div>
-                <div className="mt-1 flex items-center justify-end space-x-4">
+                <PlanInfo
+                  icon={<PiMapPinAreaBold size="18" color="#f00" />}
+                  title="여행지"
+                  content={plan.plan_country}
+                />
+                <PlanInfo
+                  icon={<BsPeopleFill size="18" />}
+                  title="인원"
+                  content={`${plan.head_count}명`}
+                />
+                <div className="mt-1.5 flex items-center justify-end space-x-4">
                   <div className="flex space-x-1">
                     <BiMoneyWithdraw size="20" color="#a88b42" />
                     <p className="font-semibold">예상 경비</p>
@@ -101,7 +105,7 @@ function PlanListPage() {
           </div>
         ))}
       </ul>
-      <div className="flex space-x-4">
+      <div className="fixed bottom-2 space-x-4">
         <button
           onClick={handlePrevPage}
           disabled={currentPage === 1}

--- a/frontend/src/pages/PlanListPage.tsx
+++ b/frontend/src/pages/PlanListPage.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from 'react'
 import { BiMoneyWithdraw } from 'react-icons/bi'
 import { BsPeopleFill } from 'react-icons/bs'
 import { GiAirplaneArrival, GiAirplaneDeparture } from 'react-icons/gi'
+import { MdNavigateBefore, MdNavigateNext } from 'react-icons/md'
 import { PiMapPinAreaBold } from 'react-icons/pi'
+import { RiArrowRightDoubleFill } from 'react-icons/ri'
 import { Link } from 'react-router-dom'
 
 import { fetchPlans } from '@/api/plans.api'
@@ -12,10 +14,30 @@ import { formatDate, formatNumber } from '@/utils/format'
 
 function PlanListPage() {
   const [plans, setPlans] = useState<Plan[]>([])
+  const [currentPage, setCurrentPage] = useState(1)
+  const plansPerPage = 5
+
+  const indexOfLastPlan = currentPage * plansPerPage
+  const indexOfFirstPlan = indexOfLastPlan - plansPerPage
+  const currentPlans = plans.slice(indexOfFirstPlan, indexOfLastPlan)
+  const totalPages = Math.ceil(plans.length / plansPerPage)
+
+  const handleNextPage = () => {
+    if (currentPage < totalPages) {
+      setCurrentPage(currentPage + 1)
+    }
+  }
+
+  const handlePrevPage = () => {
+    if (currentPage > 1) {
+      setCurrentPage(currentPage - 1)
+    }
+  }
 
   useEffect(() => {
     const getPlans = async () => {
       const plansData = await fetchPlans()
+
       setPlans(plansData)
     }
 
@@ -23,43 +45,79 @@ function PlanListPage() {
   }, [])
 
   return (
-    <div className="h-screen items-center justify-center">
-      <ul className="w-full max-w-3xl space-y-4">
-        {plans.map((plan) => (
-          <li
-            key={plan.id}
-            className="mx-2 mt-3 rounded-2xl bg-primary-50 p-4 text-base shadow-lg lg:text-sm"
-          >
-            <Link to={routes.plan}>
-              <h2 className="mb-2 text-xl font-semibold lg:text-lg">
-                {plan.plan_name}
-              </h2>
-              <div className="flex justify-between">
-                <div className="flex items-center space-x-2">
-                  <GiAirplaneDeparture size="20" color="#96948f" />
-                  <p>출발일 : {formatDate(plan.start_date)}</p>
+    <div className="flex flex-1 flex-col items-center gap-y-3">
+      <ul className="w-full max-w-3xl space-y-2.5">
+        {currentPlans.map((plan, index) => (
+          <div key={plan.id}>
+            {index > 0 &&
+              plan.plan_end !== currentPlans[index - 1].plan_end && (
+                <hr className="mx-4 my-4 border-t-2 border-dotted border-gray-400" />
+              )}
+            <li
+              className={`mx-4 rounded-2xl p-4 text-sm shadow-lg ${
+                plan.plan_end ? 'bg-gray-300' : 'bg-primary-50'
+              }`}
+            >
+              <Link to={routes.plan}>
+                <h2 className="mb-1.5 text-xl font-semibold lg:text-lg">
+                  {plan.plan_name}
+                </h2>
+                <div className="flex justify-between">
+                  <div className="mb-1 flex items-center space-x-2">
+                    <GiAirplaneDeparture size="20" color="#96948f" />
+                    <p>{formatDate(plan.start_date)}</p>
+                  </div>
+                  <div className="mb-1 flex items-center">
+                    <RiArrowRightDoubleFill size="20" />
+                  </div>
+                  <div className="mb-1 flex items-center space-x-2">
+                    <GiAirplaneArrival size="20" color="#96948f" />
+                    <p>{formatDate(plan.end_date)}</p>
+                  </div>
                 </div>
-
-                <div className="flex items-center space-x-2">
-                  <GiAirplaneArrival size="20" color="#96948f" />
-                  <p>도착일 : {formatDate(plan.end_date)}</p>
+                <div className="mb-1 flex items-center justify-between space-x-2">
+                  <div className="flex space-x-2">
+                    <PiMapPinAreaBold size="18" color="#f00" />
+                    <p className="font-semibold">여행지</p>
+                  </div>
+                  <p>{plan.plan_country}</p>
                 </div>
-              </div>
-              <div className="flex items-center space-x-2">
-                <PiMapPinAreaBold size="18" color="#f00" />{' '}
-                <p>여행지 : {plan.plan_country}</p>
-              </div>
-              <div className="flex items-center space-x-2">
-                <BsPeopleFill size="18" /> <p>인원 : {plan.head_count}명</p>
-              </div>
-              <div className="mt-2 flex items-center justify-end space-x-2">
-                <BiMoneyWithdraw size="20" color="#a88b42" />{' '}
-                <p>예상 경비 : {formatNumber(plan.total_expenses)}원</p>
-              </div>
-            </Link>
-          </li>
+                <div className="mb-1 flex items-center justify-between space-x-2">
+                  <div className="flex space-x-2">
+                    <BsPeopleFill size="18" />
+                    <p className="font-semibold">인원</p>
+                  </div>
+                  <p>{plan.head_count}명</p>
+                </div>
+                <div className="mt-1 flex items-center justify-end space-x-4">
+                  <div className="flex space-x-1">
+                    <BiMoneyWithdraw size="20" color="#a88b42" />
+                    <p className="font-semibold">예상 경비</p>
+                  </div>
+                  <p>{formatNumber(plan.total_expenses)}원</p>
+                </div>
+              </Link>
+            </li>
+          </div>
         ))}
       </ul>
+      <div className="flex space-x-4">
+        <button
+          onClick={handlePrevPage}
+          disabled={currentPage === 1}
+          className="rounded-md bg-gray-200 px-4 py-2 disabled:opacity-50"
+        >
+          <MdNavigateBefore size="20" />
+        </button>
+        <span className="px-4 py-2">{`${currentPage} / ${totalPages}`}</span>
+        <button
+          onClick={handleNextPage}
+          disabled={currentPage === totalPages}
+          className="rounded-md bg-gray-200 px-4 py-2 disabled:opacity-50"
+        >
+          <MdNavigateNext size="20" />
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## ✅ ISSUE 번호

## ✅ 작업 내용
- sorting plans
- react-icons 사용하여 plan 내부 데이터 UI 개선
- plan_end true, 즉 여행이 끝난 plan은 회색 처리, false와 true 사이에 경계선 추가
![스크린샷 2024-08-23 오후 7 26 01](https://github.com/user-attachments/assets/d6a7f8bd-7b22-481b-ab94-92228b2e7555)
![image](https://github.com/user-attachments/assets/d866e9f4-25e3-453c-a771-04fd7c025efc)



## ✅ 리뷰 요청사항
