### PR TITLE
[FEAT] (FE) 일정 리스트 출력, 일정 수정 컴포넌트

### DIFF
--- a/frontend/src/components/common/ButtonItem.tsx
+++ b/frontend/src/components/common/ButtonItem.tsx
@@ -1,6 +1,6 @@
 type Props = {
   name: string
-  color: string
+  color?: string
   onClick: () => void
 }
 const ButtonItem = ({ name, color, onClick }: Props) => {

--- a/frontend/src/components/planDetail/activity/ActivityItem.tsx
+++ b/frontend/src/components/planDetail/activity/ActivityItem.tsx
@@ -194,7 +194,7 @@ function ActivityItem({ activity }: Props) {
   }
 
   return (
-    <div className="text-s mb-3 max-w-md rounded-lg border border-gray-300 bg-gray-100 p-4">
+    <div className="text-s mb-3 max-w-md rounded-lg bg-gray-50 p-4 shadow-container">
       <div className="flex justify-end space-x-2">
         <button onClick={handleEditClick}>
           <FiEdit3 />

--- a/frontend/src/components/planDetail/activity/ActivityItem.tsx
+++ b/frontend/src/components/planDetail/activity/ActivityItem.tsx
@@ -1,5 +1,219 @@
-function ActivityItem() {
-  return <div>activity item</div>
+import { FiEdit3 } from 'react-icons/fi'
+import { RiDeleteBin6Line } from 'react-icons/ri'
+
+import ButtonItem from '@/components/common/ButtonItem'
+import { dayCategories } from '@/constants'
+import { useActivityStore } from '@/store/activity'
+import { Activity } from '@/types/plan'
+import { cn } from '@/utils/cn'
+
+type Props = {
+  activity: Activity
+  editingActivityId: string
+  setEditingActivityId: (id: string) => void
+}
+
+type EditActivityProps = {
+  editingItem: Activity
+  setActivity: (activity: Activity) => void
+  handleSaveClick: () => void
+  handleCancelClick: () => void
+}
+
+type ShowActivityProps = {
+  activity: Activity
+}
+
+function EditActivity({
+  editingItem,
+  setActivity,
+  handleSaveClick,
+  handleCancelClick,
+}: EditActivityProps) {
+  return (
+    <div>
+      <div className="mb-3 flex items-center">
+        <div className="w-20 font-bold">카테고리</div>
+        <div className="grid grid-cols-4">
+          {dayCategories.map((category, index) => {
+            const isSelected = category.name === editingItem.category
+
+            return (
+              <div
+                key={index}
+                className={cn([
+                  'm-1 rounded-lg',
+                  isSelected ? 'border border-gray-300 shadow-container' : '',
+                  category.color,
+                ])}
+              >
+                <ButtonItem
+                  name={category.name}
+                  onClick={() =>
+                    setActivity({ ...editingItem, category: category.name })
+                  }
+                />
+              </div>
+            )
+          })}
+        </div>
+      </div>
+      <div className="mb-3 flex">
+        <div className="w-20 font-bold">활동명</div>
+        <input
+          type="text"
+          className="rounded-lg border px-2 py-1"
+          value={editingItem.activityName}
+          onChange={(e) =>
+            setActivity({
+              ...editingItem,
+              activityName: e.target.value,
+            })
+          }
+        />
+      </div>
+      <div className="mb-3 flex">
+        <div className="w-20 font-bold">장소</div>
+        <input
+          type="text"
+          className="rounded-lg border px-2 py-1"
+          value={editingItem.activityPlaceName}
+          onChange={(e) =>
+            setActivity({
+              ...editingItem,
+              activityPlaceName: e.target.value,
+            })
+          }
+        />
+      </div>
+      <div className="mb-3 flex">
+        <div className="w-20 font-bold">메모</div>
+        <input
+          type="text"
+          className="rounded-lg border px-2 py-1"
+          value={editingItem.activityDetail}
+          onChange={(e) =>
+            setActivity({
+              ...editingItem,
+              activityDetail: e.target.value,
+            })
+          }
+        />
+      </div>
+      <div className="mb-3 flex">
+        <div className="w-20 font-bold">경비</div>
+        <input
+          type="number"
+          className="rounded-lg border px-2 py-1"
+          value={editingItem.activityExpense}
+          onChange={(e) =>
+            setActivity({
+              ...editingItem,
+              activityExpense: Number(e.target.value),
+            })
+          }
+        />
+      </div>
+      <div className="flex space-x-2">
+        <button
+          onClick={handleSaveClick}
+          className="flex w-full items-center justify-center rounded-lg bg-blue-500 p-2 text-white"
+        >
+          수정
+        </button>
+        <button
+          onClick={handleCancelClick}
+          className="w-full rounded-lg border border-gray-300 bg-white px-2 py-2 text-gray-400"
+        >
+          취소
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function ShowActivity({ activity }: ShowActivityProps) {
+  const categoryName = dayCategories.find(
+    (category) => category.name === activity.category
+  )?.name
+  const categoryColor = dayCategories.find(
+    (category) => category.name === activity.category
+  )?.color
+
+  return (
+    <div>
+      <div className="mb-3 flex">
+        <div className="w-20 font-bold">카테고리</div>
+        <button
+          className={cn([`rounded-lg px-2 py-1 text-xs ${categoryColor}`])}
+        >
+          {categoryName}
+        </button>
+      </div>
+      <div className="mb-3 flex">
+        <div className="w-20 font-bold">활동명</div>
+        <div>{activity.activityName}</div>
+      </div>
+      <div className="mb-3 flex">
+        <div className="w-20 font-bold">장소</div>
+        <div>{activity.activityPlaceName}</div>
+      </div>
+      <div className="mb-3 flex">
+        <div className="w-20 font-bold">메모</div>
+        <div>{activity.activityDetail}</div>
+      </div>
+      <div className="flex">
+        <div className="w-20 font-bold">경비</div>
+        <div>{activity.activityExpense}</div>
+      </div>
+    </div>
+  )
+}
+
+function ActivityItem({ activity }: Props) {
+  const {
+    activity: editingItem,
+    editingActivityId,
+    setActivity,
+    setEditingActivityId,
+  } = useActivityStore()
+
+  const handleEditClick = () => {
+    setEditingActivityId(activity.id)
+    setActivity(activity)
+  }
+
+  const handleSaveClick = () => {
+    // acitivy 수정 api 콜
+    console.log(editingItem)
+    setEditingActivityId('')
+  }
+
+  const handleCancelClick = () => {
+    setEditingActivityId('')
+  }
+
+  return (
+    <div className="text-s mb-3 max-w-md rounded-lg border border-gray-300 bg-gray-100 p-4">
+      <div className="flex justify-end space-x-2">
+        <button onClick={handleEditClick}>
+          <FiEdit3 />
+        </button>
+        <RiDeleteBin6Line />
+      </div>
+
+      {editingActivityId === activity.id ? (
+        <EditActivity
+          editingItem={editingItem}
+          setActivity={setActivity}
+          handleSaveClick={handleSaveClick}
+          handleCancelClick={handleCancelClick}
+        />
+      ) : (
+        <ShowActivity activity={activity} />
+      )}
+    </div>
+  )
 }
 
 export default ActivityItem

--- a/frontend/src/components/planDetail/activity/ActivityList.tsx
+++ b/frontend/src/components/planDetail/activity/ActivityList.tsx
@@ -11,7 +11,7 @@ type Props = {
 function ActivityList({ activities }: Props) {
   const [editingActivityId, setEditingActivityId] = useState('')
   return (
-    <div>
+    <div className="text-sm">
       {activities.map((activity) => (
         <ActivityItem
           key={activity.id}

--- a/frontend/src/components/planDetail/activity/ActivityList.tsx
+++ b/frontend/src/components/planDetail/activity/ActivityList.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import { Activity } from '@/types/plan'
 
 import ActivityItem from './ActivityItem'
@@ -7,10 +9,16 @@ type Props = {
 }
 
 function ActivityList({ activities }: Props) {
+  const [editingActivityId, setEditingActivityId] = useState('')
   return (
     <div>
       {activities.map((activity) => (
-        <ActivityItem key={activity.id} />
+        <ActivityItem
+          key={activity.id}
+          activity={activity}
+          editingActivityId={editingActivityId}
+          setEditingActivityId={setEditingActivityId}
+        />
       ))}
     </div>
   )

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -17,6 +17,7 @@ export const dummyDays: DaysResDto = [
         activityPlaceName: 'Tokyo Tower',
         activityDetail: 'Sightseeing at the iconic Tokyo Tower.',
         activityExpense: 50,
+        category: '활동',
       },
       {
         id: 'activity-2',

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -27,6 +27,7 @@ export const dummyDays: DaysResDto = [
         activityPlaceName: 'Sushi Zanmai',
         activityDetail: 'Enjoying traditional sushi.',
         activityExpense: 30,
+        category: '점심',
       },
       {
         id: 'activity-3',
@@ -36,6 +37,7 @@ export const dummyDays: DaysResDto = [
         activityPlaceName: 'Asakusa',
         activityDetail: 'Exploring the historic temple.',
         activityExpense: 20,
+        category: '활동',
       },
     ],
   },
@@ -55,6 +57,7 @@ export const dummyDays: DaysResDto = [
         activityPlaceName: 'Fushimi Inari',
         activityDetail: 'Walking through the famous Torii gates.',
         activityExpense: 0,
+        category: '활동',
       },
       {
         id: 'activity-5',
@@ -64,6 +67,7 @@ export const dummyDays: DaysResDto = [
         activityPlaceName: 'Nishiki Market',
         activityDetail: 'Tasting local street food.',
         activityExpense: 25,
+        category: '점심',
       },
       {
         id: 'activity-6',
@@ -73,6 +77,7 @@ export const dummyDays: DaysResDto = [
         activityPlaceName: 'Kiyomizu-dera',
         activityDetail: 'Exploring the famous temple with a view.',
         activityExpense: 20,
+        category: '활동',
       },
     ],
   },
@@ -92,6 +97,7 @@ export const dummyDays: DaysResDto = [
         activityPlaceName: 'Osaka Castle',
         activityDetail: 'Exploring the historic castle and park.',
         activityExpense: 25,
+        category: '활동',
       },
       {
         id: 'activity-8',
@@ -101,6 +107,7 @@ export const dummyDays: DaysResDto = [
         activityPlaceName: 'Dotonbori',
         activityDetail: 'Enjoying Takoyaki and Okonomiyaki.',
         activityExpense: 35,
+        category: '점심',
       },
       {
         id: 'activity-9',
@@ -110,6 +117,7 @@ export const dummyDays: DaysResDto = [
         activityPlaceName: 'Universal Studios Japan',
         activityDetail: 'Experiencing theme park attractions.',
         activityExpense: 100,
+        category: '활동',
       },
     ],
   },

--- a/frontend/src/store/activity.ts
+++ b/frontend/src/store/activity.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand'
+
+import { Activity } from '@/types/plan'
+
+const initialState: Activity = {
+  id: '',
+  planId: '',
+  dayId: '',
+  activityName: '',
+  activityPlaceName: '',
+  activityDetail: '',
+  activityExpense: 0,
+  category: '',
+}
+
+type ActivityStore = {
+  activity: Activity
+  editingActivityId: string
+  setActivity: (activity: Activity) => void
+  setEditingActivityId: (id: string) => void
+}
+
+export const useActivityStore = create<ActivityStore>((set) => ({
+  activity: initialState,
+  editingActivityId: '',
+  setActivity: (activity) => set({ activity }),
+  setEditingActivityId: (id) => set({ editingActivityId: id }),
+}))

--- a/frontend/src/types/plan.ts
+++ b/frontend/src/types/plan.ts
@@ -38,6 +38,7 @@ export type Activity = {
   activityPlaceName: string
   activityDetail: string
   activityExpense: number
+  category?: string
 }
 
 export type Day = {


### PR DESCRIPTION
## ✅ ISSUE 번호

## ✅ 작업 내용
![image](https://github.com/user-attachments/assets/9201c3c0-f38d-40c7-bd3f-4a9ec4540d89)
- dummyDays에 category 속성이 없어서 추가하였습니다. 
- 일정 리스트에 담긴 객체들의 "카테고리, 활동명, 장소, 메모, 경비" 를 출력합니다. 

![image](https://github.com/user-attachments/assets/d6bcd5f8-d70d-4d89-a7ee-7a0a75d55f3d)
- 각 일정 우측 상단의 편집 아이콘을 누르면 편집을 위한 폼으로 바뀌고, 이전에 저장되어 있던 내용은 입력되어 있습니다.
- 내용을 수정한 뒤 수정 버튼을 누르면 수정된 Activity 객체가 콘솔로 출력되도록 구현해두었습니다. 
![image](https://github.com/user-attachments/assets/0a012d2e-3670-4b91-8a84-4c57ac557c1f)

## ✅ 리뷰 요청사항
수정 페이지 http://localhost:5173/plans/:id  입니다. 