### PR TITLE
[FEAT] (BE) : get '/city' & '/city/:id' api 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,6 +16,10 @@ import { Users } from './entities/users.entity';
 import { ConfigModule } from '@nestjs/config';
 import { HttpModule } from '@nestjs/axios';
 import { Plan } from './modules/plan/entities/plan.entity';
+import { CountryModule } from './modules/country/country.module';
+import { CityModule } from './modules/city/city.module';
+import { City } from './modules/city/entities/city.entity';
+import { Country } from './modules/country/entities/country.entity';
 
 @Module({
   imports: [
@@ -30,11 +34,11 @@ import { Plan } from './modules/plan/entities/plan.entity';
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,
-      entities: [Users, Plan],
+      entities: [Users, Plan, City, Country],
       charset: 'utf8mb4_general_ci',
       synchronize: false,
       logging: process.env.NODE_ENV === 'development',
-      migrations: [__dirname + '/migrations/**/*{.ts,.js}']
+      migrations: [__dirname + '/migrations/**/*{.ts,.js}'],
     }),
     JwtModule.register({
       global: true,
@@ -53,6 +57,8 @@ import { Plan } from './modules/plan/entities/plan.entity';
     UploadModule,
     CostModule,
     PlanModule,
+    CountryModule,
+    CityModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/modules/city/city.controller.ts
+++ b/backend/src/modules/city/city.controller.ts
@@ -22,7 +22,7 @@ export class CityController {
   }
 
   @Get()
-  findAll() {
+  async findAll(): Promise<CityResDto[]> {
     return this.cityService.findAll();
   }
 

--- a/backend/src/modules/city/city.controller.ts
+++ b/backend/src/modules/city/city.controller.ts
@@ -1,0 +1,43 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { CityService } from './city.service';
+import { CreateCityDto } from './dto/create-city.dto';
+import { UpdateCityDto } from './dto/update-city.dto';
+import { CityResDto } from './dto/response-city.dto';
+
+@Controller('city')
+export class CityController {
+  constructor(private readonly cityService: CityService) {}
+
+  @Post()
+  create(@Body() createCityDto: CreateCityDto) {
+    return this.cityService.create(createCityDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.cityService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string): Promise<CityResDto> {
+    return this.cityService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateCityDto: UpdateCityDto) {
+    return this.cityService.update(+id, updateCityDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.cityService.remove(+id);
+  }
+}

--- a/backend/src/modules/city/city.module.ts
+++ b/backend/src/modules/city/city.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CityService } from './city.service';
+import { CityController } from './city.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { City } from './entities/city.entity';
+import { Country } from '../country/entities/country.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([City, Country])],
+  controllers: [CityController],
+  providers: [CityService],
+})
+export class CityModule {}

--- a/backend/src/modules/city/city.service.ts
+++ b/backend/src/modules/city/city.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { CreateCityDto } from './dto/create-city.dto';
+import { UpdateCityDto } from './dto/update-city.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { City } from './entities/city.entity';
+import { Country } from '../country/entities/country.entity';
+import { Repository } from 'typeorm';
+import { CityResDto } from './dto/response-city.dto';
+
+@Injectable()
+export class CityService {
+  constructor(
+    @InjectRepository(City)
+    private readonly cityRepository: Repository<City>,
+    @InjectRepository(Country)
+    private readonly countryRepository: Repository<Country>,
+  ) {}
+
+  create(createCityDto: CreateCityDto) {
+    return 'This action adds a new city';
+  }
+
+  findAll() {
+    return `This action returns all city`;
+  }
+
+  async findOne(id: number) {
+    const city = await this.cityRepository.findOne({
+      where: { id },
+      relations: ['country'],
+    });
+    if (!city) {
+      return null;
+    }
+    return this.transformToResponseDto(city);
+  }
+
+  update(id: number, updateCityDto: UpdateCityDto) {
+    return `This action updates a #${id} city`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} city`;
+  }
+
+  private transformToResponseDto(city: City): CityResDto {
+    const responseDto: CityResDto = {
+      city_name: city.city_name,
+      country_name: city.country ? city.country.country_name : undefined,
+    };
+    return responseDto;
+  }
+}

--- a/backend/src/modules/city/city.service.ts
+++ b/backend/src/modules/city/city.service.ts
@@ -20,8 +20,9 @@ export class CityService {
     return 'This action adds a new city';
   }
 
-  findAll() {
-    return `This action returns all city`;
+  async findAll() {
+    const cities = await this.cityRepository.find({ relations: ['country'] });
+    return cities.map(city => this.transformToResponseDto(city));
   }
 
   async findOne(id: number) {

--- a/backend/src/modules/city/dto/create-city.dto.ts
+++ b/backend/src/modules/city/dto/create-city.dto.ts
@@ -1,0 +1,12 @@
+import { IsDecimal, IsString } from 'class-validator';
+
+export class CreateCityDto {
+  @IsString()
+  city_name: string;
+
+  @IsDecimal({ decimal_digits: '6,6', force_decimal: true })
+  latitude: number;
+
+  @IsDecimal({ decimal_digits: '6,6', force_decimal: true })
+  longitude: number;
+}

--- a/backend/src/modules/city/dto/response-city.dto.ts
+++ b/backend/src/modules/city/dto/response-city.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsString } from "class-validator";
+
+export class CityResDto {
+    @IsString()
+    city_name: string;
+
+    @IsString()
+    @IsOptional()
+    country_name?: String;
+}

--- a/backend/src/modules/city/dto/update-city.dto.ts
+++ b/backend/src/modules/city/dto/update-city.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateCityDto } from './create-city.dto';
+
+export class UpdateCityDto extends PartialType(CreateCityDto) {}

--- a/backend/src/modules/city/entities/city.entity.ts
+++ b/backend/src/modules/city/entities/city.entity.ts
@@ -1,0 +1,31 @@
+import { Country } from "src/modules/country/entities/country.entity";
+import { Column, Entity, JoinColumn, ManyToMany, ManyToOne, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity('city')
+export class City {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    city_name: string;
+
+    @Column({
+        type: 'decimal',
+        precision: 9,
+        scale: 6,
+        nullable: false
+    })
+    latitude: number;
+
+    @Column({
+        type: 'decimal',
+        precision: 9,
+        scale: 6,
+        nullable: false
+    })
+    longitude: number;
+
+    @ManyToOne(() => Country, (country) => country.cities)
+    @JoinColumn({ name: 'country_id' })
+    country: Country;
+}

--- a/backend/src/modules/country/country.controller.ts
+++ b/backend/src/modules/country/country.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { CountryService } from './country.service';
+import { CreateCountryDto } from './dto/create-country.dto';
+import { UpdateCountryDto } from './dto/update-country.dto';
+
+@Controller('country')
+export class CountryController {
+  constructor(private readonly countryService: CountryService) {}
+
+  @Post()
+  create(@Body() createCountryDto: CreateCountryDto) {
+    return this.countryService.create(createCountryDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.countryService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.countryService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateCountryDto: UpdateCountryDto) {
+    return this.countryService.update(+id, updateCountryDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.countryService.remove(+id);
+  }
+}

--- a/backend/src/modules/country/country.module.ts
+++ b/backend/src/modules/country/country.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { CountryService } from './country.service';
+import { CountryController } from './country.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Country } from './entities/country.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Country])],
+  controllers: [CountryController],
+  providers: [CountryService],
+})
+export class CountryModule {}

--- a/backend/src/modules/country/country.service.ts
+++ b/backend/src/modules/country/country.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateCountryDto } from './dto/create-country.dto';
+import { UpdateCountryDto } from './dto/update-country.dto';
+
+@Injectable()
+export class CountryService {
+  create(createCountryDto: CreateCountryDto) {
+    return 'This action adds a new country';
+  }
+
+  findAll() {
+    return `This action returns all country`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} country`;
+  }
+
+  update(id: number, updateCountryDto: UpdateCountryDto) {
+    return `This action updates a #${id} country`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} country`;
+  }
+}

--- a/backend/src/modules/country/dto/create-country.dto.ts
+++ b/backend/src/modules/country/dto/create-country.dto.ts
@@ -1,0 +1,20 @@
+import { IsDecimal, IsString, Length } from 'class-validator';
+
+export class CreateCountryDto {
+  @IsString()
+  country_name: string;
+
+  @IsString()
+  @Length(2, 2)
+  country_code: string;
+
+  @IsString()
+  @Length(3, 3)
+  currency_code: string;
+
+  @IsDecimal({ decimal_digits: '7,7', force_decimal: true })
+  latitude: number;
+
+  @IsDecimal({ decimal_digits: '7,7', force_decimal: true })
+  longitude: number;
+}

--- a/backend/src/modules/country/dto/update-country.dto.ts
+++ b/backend/src/modules/country/dto/update-country.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateCountryDto } from './create-country.dto';
+
+export class UpdateCountryDto extends PartialType(CreateCountryDto) {}

--- a/backend/src/modules/country/entities/country.entity.ts
+++ b/backend/src/modules/country/entities/country.entity.ts
@@ -1,0 +1,42 @@
+import { City } from "src/modules/city/entities/city.entity";
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity('country')
+export class Country {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    country_name: string;
+
+    @Column({
+        type: 'char',
+        length: 2
+    })
+    country_code: string;
+
+    @Column({
+        type: 'char',
+        length: 3
+    })
+    currency_code: string;
+
+    @Column({
+        type: 'decimal',
+        precision: 10,
+        scale: 7,
+        nullable: false
+    })
+    latitude: number;
+
+    @Column({
+        type: 'decimal',
+        precision: 10,
+        scale: 7,
+        nullable: false
+    })
+    longitude: number;
+
+    @OneToMany(() => City, (city) => city.country)
+    cities: City[];
+}

--- a/backend/src/modules/plan/entities/plan.entity.ts
+++ b/backend/src/modules/plan/entities/plan.entity.ts
@@ -1,6 +1,5 @@
 import {
   Column,
-  CreateDateColumn,
   Entity,
   PrimaryGeneratedColumn,
 } from 'typeorm';


### PR DESCRIPTION
## ✅ ISSUE 번호
#65 
## ✅ 작업 내용
- city 모듈 생성
- counrty 모듈 생성
- city service 내에서 city_name과 country_name 가져오기
- city_name과 country_name로 결과물이 출력되도록  CityResDto 추가 생성
<img width="596" alt="image" src="https://github.com/user-attachments/assets/1e5e16d0-c348-4777-962d-026909088357">

- get '/city' api
![image](https://github.com/user-attachments/assets/d062ba9a-1de2-49ce-a434-d21a1972b227)

- get 'city/:id' api
![image](https://github.com/user-attachments/assets/a528686d-a61f-433b-af36-463d90a706aa)


## ✅ 리뷰 요청사항
