### PR TITLE
[FEAT] (FE) 단일 활동 폼 추가

### DIFF
--- a/frontend/src/components/addPlan/SetInfoForm.tsx
+++ b/frontend/src/components/addPlan/SetInfoForm.tsx
@@ -16,7 +16,7 @@ function SetInfoForm() {
   } = useFormContext()
 
   return (
-    <div className="flex flex-col gap-y-8">
+    <div className="flex flex-col gap-y-4">
       <Controller
         name="name"
         control={control}

--- a/frontend/src/components/common/Field.tsx
+++ b/frontend/src/components/common/Field.tsx
@@ -3,13 +3,14 @@ import React from 'react'
 type Props = {
   name: string
   value: React.ReactNode | string
+  isRequired?: boolean
 }
 
-function Field({ name, value }: Props) {
+function Field({ name, value, isRequired }: Props) {
   return (
     <div className="flex w-full gap-x-4 py-2">
-      <span className="inline-block min-w-20 text-nowrap text-gray-500">
-        {name}
+      <span className="inline-block min-w-20 text-nowrap text-sm text-gray-500">
+        {name} {isRequired && <span className="font-bold text-red-400">*</span>}
       </span>
 
       <div className="w-full">

--- a/frontend/src/components/common/Input.tsx
+++ b/frontend/src/components/common/Input.tsx
@@ -43,8 +43,10 @@ const Input = forwardRef<HTMLInputElement, Props>(
     }
 
     return (
-      <div className="relative flex w-full flex-col gap-y-2">
-        {!!label && <label className="text-sm text-gray-500">{label}</label>}
+      <div className="flex w-full flex-col gap-y-1">
+        {!!label && (
+          <label className="mb-1 text-sm text-gray-500">{label}</label>
+        )}
         {/* text type input */}
         {type === 'text' && (
           <input
@@ -88,9 +90,7 @@ const Input = forwardRef<HTMLInputElement, Props>(
           </div>
         )}
         {!!errorMessage && (
-          <p className="absolute bottom-[-24px] left-0 text-sm text-red-500">
-            {errorMessage}
-          </p>
+          <p className="text-sm text-red-500">{errorMessage}</p>
         )}
       </div>
     )

--- a/frontend/src/components/planDetail/DaySection.tsx
+++ b/frontend/src/components/planDetail/DaySection.tsx
@@ -23,8 +23,11 @@ function DaySection({ day, dayIndex }: Props) {
     setCurrentTab(tab)
     setShowForm(false)
   }
-  const addForm = () => {
+  const openForm = () => {
     setShowForm(true)
+  }
+  const closeForm = () => {
+    setShowForm(false)
   }
 
   return (
@@ -43,15 +46,17 @@ function DaySection({ day, dayIndex }: Props) {
         <DayTabs
           currentTab={currentTab}
           changeCurrentTab={changeCurrentTab}
-          addForm={addForm}
+          openForm={openForm}
         />
 
         {/* content */}
+        {showForm && (
+          <ActivityForm handleCancel={closeForm} handleSave={() => {}} />
+        )}
         {currentTab === DaysTabEnum.Activity && (
           <ActivityList activities={activities} />
         )}
         {currentTab === DaysTabEnum.Expense && <ExpenseTable />}
-        {showForm && <ActivityForm />}
       </div>
     </div>
   )

--- a/frontend/src/components/planDetail/DayTabs.tsx
+++ b/frontend/src/components/planDetail/DayTabs.tsx
@@ -6,10 +6,10 @@ import { cn } from '@/utils/cn'
 type Props = {
   currentTab: DaysTabEnum
   changeCurrentTab: (tab: DaysTabEnum) => void
-  addForm: () => void
+  openForm: () => void
 }
 
-function DayTabs({ currentTab, changeCurrentTab, addForm }: Props) {
+function DayTabs({ currentTab, changeCurrentTab, openForm }: Props) {
   return (
     <div className="flex items-center justify-between">
       <div className="flex">
@@ -29,7 +29,7 @@ function DayTabs({ currentTab, changeCurrentTab, addForm }: Props) {
         ))}
       </div>
 
-      <button onClick={addForm}>
+      <button onClick={openForm}>
         <FiPlusSquare className="text-2xl text-primary-default" />
       </button>
     </div>

--- a/frontend/src/components/planDetail/activity/ActivityForm.tsx
+++ b/frontend/src/components/planDetail/activity/ActivityForm.tsx
@@ -1,5 +1,141 @@
-function ActivityForm() {
-  return <div>activity form</div>
+import { useMemo, useState } from 'react'
+import { useForm } from 'react-hook-form'
+
+import { Button, Field, Input } from '@/components/common'
+import { errorMessages } from '@/constants/errorMessage'
+import { ActivityReqDto, DayCategoryEnum } from '@/types/plan'
+import { cn } from '@/utils/cn'
+
+import CategoryList from './CategoryList'
+import ExpenseInput from './ExpenseInput'
+import LocationInput from './LocationInput'
+
+type Props = {
+  defaultValues?: ActivityReqDto
+  handleCancel: () => void
+  handleSave: (payload: ActivityReqDto) => void
+}
+
+const initialValues: ActivityReqDto = {
+  category: null,
+  activityName: '',
+  activityLocation: null,
+  activityDetail: null,
+  activityExpenses: null,
+}
+
+function ActivityForm({ defaultValues, handleCancel, handleSave }: Props) {
+  const [activityPayload, setActivityPayload] = useState<ActivityReqDto>(
+    defaultValues || initialValues
+  )
+  const {
+    register,
+    formState: { errors, isDirty },
+  } = useForm<Partial<ActivityReqDto>>({
+    defaultValues: defaultValues || initialValues,
+    mode: 'onChange',
+  })
+
+  const isValid = useMemo(
+    () =>
+      defaultValues
+        ? !errors.activityName && !!activityPayload.category
+        : !errors.activityName && !!activityPayload.category && isDirty,
+    [errors, activityPayload.category, isDirty]
+  )
+  const updatePayload = (value: Partial<ActivityReqDto>) => {
+    setActivityPayload({
+      ...activityPayload,
+      ...value,
+    })
+  }
+
+  return (
+    <form className="rounded-md border border-gray-300 p-4">
+      <Field
+        name="카테고리"
+        value={
+          <CategoryList
+            selectedCategory={activityPayload.category as DayCategoryEnum}
+            onClick={(category) => updatePayload({ category })}
+          />
+        }
+        isRequired
+      />
+      <Field
+        name="활동명"
+        value={
+          <Input
+            {...register('activityName', {
+              required: {
+                value: true,
+                message: errorMessages.addActivity.nameRequired,
+              },
+              minLength: {
+                value: 1,
+                message: errorMessages.addActivity.nameRequired,
+              },
+              maxLength: {
+                value: 15,
+                message: errorMessages.addActivity.nameMaxLength,
+              },
+              value: activityPayload.activityName,
+              onChange: (e) => updatePayload({ activityName: e.target.value }),
+            })}
+            type="text"
+            className="p-2 text-sm"
+            placeholder="활동명을 입력해주세요"
+            errorMessage={errors.activityName && errors.activityName.message}
+          />
+        }
+        isRequired
+      />
+      <Field
+        name="장소"
+        value={
+          <LocationInput
+            defaultValue={activityPayload.activityLocation}
+            updatePayload={updatePayload}
+          />
+        }
+      />
+      <Field
+        name="메모"
+        value={
+          <textarea
+            {...register('activityDetail', {
+              value: activityPayload.activityDetail,
+              onChange: (e) =>
+                updatePayload({ activityDetail: e.target.value }),
+            })}
+            className="w-full rounded-md border border-gray-300 p-2 text-sm"
+          />
+        }
+      />
+      <Field name="경비" value={<ExpenseInput />} />
+
+      <div className="mt-2 flex items-center gap-x-3">
+        <Button
+          type="button"
+          className="border border-blue-500 bg-transparent px-0 py-2 text-sm text-blue-500"
+          onClick={handleCancel}
+        >
+          취소
+        </Button>
+        <Button
+          type="button"
+          isDisabled={!isValid}
+          className={cn([
+            isValid ? 'border border-blue-500' : 'border border-gray-400',
+            'px-0 py-2 text-sm',
+          ])}
+          onClick={() => handleSave(activityPayload)}
+        >
+          저장
+        </Button>
+      </div>
+    </form>
+  )
 }
 
 export default ActivityForm

--- a/frontend/src/components/planDetail/activity/CategoryList.tsx
+++ b/frontend/src/components/planDetail/activity/CategoryList.tsx
@@ -1,0 +1,30 @@
+import { dayCategories } from '@/constants'
+import { DayCategoryEnum } from '@/types/plan'
+import { cn } from '@/utils/cn'
+
+type Props = {
+  selectedCategory: DayCategoryEnum | null
+  onClick: (category: DayCategoryEnum) => void
+}
+
+function CategoryList({ selectedCategory, onClick }: Props) {
+  return (
+    <div className="flex w-full flex-wrap items-center gap-1">
+      {dayCategories.map((category) => (
+        <button
+          key={category.name}
+          type="button"
+          className={cn([
+            'rounded-md px-2 py-1 text-center text-xs',
+            category.color,
+          ])}
+          onClick={() => onClick(category.name)}
+        >
+          {category.name} {selectedCategory === category.name && '✅'}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default CategoryList

--- a/frontend/src/components/planDetail/activity/ExpenseInput.tsx
+++ b/frontend/src/components/planDetail/activity/ExpenseInput.tsx
@@ -1,0 +1,12 @@
+import { Input } from '@/components/common'
+
+function ExpenseInput() {
+  return (
+    <div className="flex flex-col gap-y-2">
+      <Input className="p-2" />
+      {/* 환율 */}
+    </div>
+  )
+}
+
+export default ExpenseInput

--- a/frontend/src/components/planDetail/activity/LocationInput.tsx
+++ b/frontend/src/components/planDetail/activity/LocationInput.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@/components/common'
+import { ActivityReqDto } from '@/types/plan'
+
+type Props = {
+  defaultValue: string | null
+  updatePayload: (value: Partial<ActivityReqDto>) => void
+}
+
+function LocationInput({ defaultValue, updatePayload }: Props) {
+  // const { isModalOpen, openModal, closeModal } = useModal()
+
+  return (
+    <>
+      <Button shape="input" className="p-2 text-sm">
+        {defaultValue || '장소를 설정해주세요'}
+      </Button>
+    </>
+  )
+}
+
+export default LocationInput

--- a/frontend/src/constants/errorMessage.ts
+++ b/frontend/src/constants/errorMessage.ts
@@ -2,4 +2,8 @@ export const errorMessages = {
   addPlan: {
     name: '여행명을 한 글자 이상 입력해주세요.',
   },
+  addActivity: {
+    nameRequired: '활동명을 입력해주세요.',
+    nameMaxLength: '활동명은 15자 이내로 입력해주세요.',
+  },
 }

--- a/frontend/src/pages/PlanDetailPage.tsx
+++ b/frontend/src/pages/PlanDetailPage.tsx
@@ -6,7 +6,7 @@ function PlanDetailPage() {
   // TODO: get days list api call
 
   return (
-    <div className="flex w-full flex-col gap-y-4 px-3 py-2 pb-4">
+    <div className="relative flex w-full flex-col gap-y-4 px-3 py-2 pb-4">
       <div className="flex flex-col items-center gap-y-3">
         <h2 className="text-2xl font-bold">여행명</h2>
         <div className="flex items-center gap-x-2">

--- a/frontend/src/types/plan.ts
+++ b/frontend/src/types/plan.ts
@@ -35,9 +35,10 @@ export type Activity = {
   planId: string
   dayId: string
   activityName: string
-  activityPlaceName: string
-  activityDetail: string
-  activityExpense: number
+  activityLocation: string | null
+  activityDetail: string | null
+  activityExpenses: number | null
+  category: string | null
 }
 
 export type Day = {
@@ -56,3 +57,5 @@ export type DayCategory = {
 }
 
 export type DaysResDto = Day[]
+
+export type ActivityReqDto = Omit<Activity, 'id' | 'planId' | 'dayId'>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -60,7 +60,7 @@ export default {
     plugin(({ addUtilities }) =>
       addUtilities({
         '.layout': {
-          '@apply mx-auto max-w-2xl lg:max-w-4xl lg:flex lg:gap-x-10': '',
+          '@apply mx-auto max-w-lg lg:max-w-5xl lg:flex lg:gap-x-10': '',
         },
         '.container': {
           '@apply max-w-lg mx-auto min-h-dvh': '',


### PR DESCRIPTION
## ✅ ISSUE 번호
#67 

## ✅ 작업 
![스크린샷 2024-08-24 오전 12 14 40](https://github.com/user-attachments/assets/fde9b7b0-58b4-46cc-9cd0-317dcf761a9c)
   - `카테고리`, `활동명`은 필수고 나머지는 빈 스트링 또는 null로 들어가도 유효성 검사에 걸리지 않습니다.
   ```tsx
        type Props = {
            defaultValues?: ActivityReqDto
            handleCancel: () => void
            handleSave: (payload: ActivityReqDto) => void
        }
   ```
   - <ActivityForm> 컴포넌트의 props입니다.
   - defaultValues를 넘겨줄 경우에 defaultValues가 각 필드의 초기값으로 들어갑니다. @DahyeY 편집에서 기존 값들을 defaultValues에 넘겨주면 됩니다.
       ![스크린샷 2024-08-23 오후 11 07 54](https://github.com/user-attachments/assets/34a79245-619e-45de-a1ed-69dd83130545)

- 장소, 경비 필드는 확정이 아니고 컴포넌트를 분리해서 다른 pr로 올릴 예정입니다.

## ✅ 리뷰 요청사항
