### PR TITLE
[FEAT] (BE) getCurrenyCode API 구현

### DIFF
--- a/backend/src/modules/country/country.module.ts
+++ b/backend/src/modules/country/country.module.ts
@@ -8,5 +8,6 @@ import { Country } from './entities/country.entity';
   imports: [TypeOrmModule.forFeature([Country])],
   controllers: [CountryController],
   providers: [CountryService],
+  exports: [TypeOrmModule],
 })
 export class CountryModule {}

--- a/backend/src/modules/plan/plan.controller.ts
+++ b/backend/src/modules/plan/plan.controller.ts
@@ -35,6 +35,11 @@ export class PlanController {
     return this.planService.findAllDaysAndActivities(planId);
   }
 
+  @Get(':id/currency')
+  async getCurrencyCode(@Param('id') id: string): Promise<string> {
+    return this.planService.getCurrencyCode(id);
+  }
+
   @Put(':id')
   update(@Param('id') id: string, @Body() updatePlanDto: UpdatePlanDto) {
     return this.planService.update(id, updatePlanDto);

--- a/backend/src/modules/plan/plan.module.ts
+++ b/backend/src/modules/plan/plan.module.ts
@@ -5,12 +5,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Plan } from './entities/plan.entity';
 import { DayModule } from '../day/day.module';
 import { ActivityModule } from '../activity/activity.module';
+import { CountryModule } from '../country/country.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Plan]),
     forwardRef(() => DayModule),
     forwardRef(() => ActivityModule),
+    CountryModule,
   ],
   controllers: [PlanController],
   providers: [PlanService],


### PR DESCRIPTION
## ✅ ISSUE 번호
#71 

## ✅ 작업 내용
- plan.service, plan.controller에 getCurrencyCode API 구현
- country db table 참조를 위해 country.module과 plan.module 수정
- 엔드포인트: GET `/plans/:planId/currency`

## ✅ 리뷰 요청사항
