### PR TITLE
[FEAT] (FE) DB에서 계획별 모든 활동 리스트 불러오기

### DIFF
--- a/frontend/src/api/Days.ts
+++ b/frontend/src/api/Days.ts
@@ -1,0 +1,32 @@
+import axios from 'axios'
+
+import { Activity, Day, DaysResDto } from '@/types/plan'
+
+export const fetchDays = async (): Promise<Day[]> => {
+  const planId = '9e74d62c-3954-41ab-9aca-780c16a61f0d'
+  try {
+    const response = await axios.get<DaysResDto>(
+      `http://localhost:3333/plans/${planId}/all`
+    )
+
+    const convertData: Day[] = response.data.map((day: Day) => {
+      const temp: Activity[] = day.activities.map((activity) => ({
+        id: activity.id,
+        isActivity: activity.isActivity,
+        order: activity.order,
+        category: activity.category,
+        activityName: activity.activity_name, // CamelCase로 변환된 이름
+        activityLocation: activity.activity_location, // CamelCase로 변환된 이름
+        detail: activity.detail,
+        activityExpenses: activity.activity_expenses,
+      }))
+
+      return { ...day, activities: temp }
+    })
+
+    return convertData
+  } catch (error) {
+    console.error('Error fetching plans:', error)
+    return []
+  }
+}

--- a/frontend/src/api/Days.ts
+++ b/frontend/src/api/Days.ts
@@ -2,8 +2,8 @@ import axios from 'axios'
 
 import { Activity, Day, DaysResDto } from '@/types/plan'
 
-export const fetchDays = async (): Promise<Day[]> => {
-  const planId = '9e74d62c-3954-41ab-9aca-780c16a61f0d'
+export const fetchDays = async (planId: string): Promise<Day[]> => {
+  // const planId = '9e74d62c-3954-41ab-9aca-780c16a61f0d'
   try {
     const response = await axios.get<DaysResDto>(
       `http://localhost:3333/plans/${planId}/all`

--- a/frontend/src/pages/PlanDetailPage.tsx
+++ b/frontend/src/pages/PlanDetailPage.tsx
@@ -1,9 +1,24 @@
+import { useEffect, useState } from 'react'
+
+import { fetchDays } from '@/api/Days'
 import DaySection from '@/components/planDetail/DaySection'
 import { dummyDays, dummyPlan } from '@/constants'
+import { Day } from '@/types/plan'
 
 function PlanDetailPage() {
   // TODO: get plan by id api call
   const { planName, planCountry, totalExpenses } = dummyPlan
+  const [days, setDays] = useState<Day[]>([])
+
+  useEffect(() => {
+    const getDays = async () => {
+      const data = await fetchDays()
+
+      setDays(data)
+    }
+
+    getDays()
+  }, [])
   // TODO: get activity list api call
 
   return (
@@ -17,7 +32,7 @@ function PlanDetailPage() {
       </div>
 
       <div className="flex flex-col gap-y-4">
-        {dummyDays.map((day, index) => (
+        {days.map((day, index) => (
           <DaySection
             key={day.id}
             day={day}

--- a/frontend/src/pages/PlanDetailPage.tsx
+++ b/frontend/src/pages/PlanDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
 
 import { fetchDays } from '@/api/Days'
 import DaySection from '@/components/planDetail/DaySection'
@@ -8,18 +9,20 @@ import { Day } from '@/types/plan'
 function PlanDetailPage() {
   // TODO: get plan by id api call
   const { planName, planCountry, totalExpenses } = dummyPlan
+
+  // TODO: get activity list api call
+  const { id: planId } = useParams<string>()
   const [days, setDays] = useState<Day[]>([])
 
   useEffect(() => {
     const getDays = async () => {
-      const data = await fetchDays()
-
-      setDays(data)
+      if (planId) {
+        const data = await fetchDays(planId)
+        setDays(data)
+      }
     }
-
     getDays()
   }, [])
-  // TODO: get activity list api call
 
   return (
     <div className="relative flex w-full flex-col gap-y-4 px-3 py-2 pb-4">


### PR DESCRIPTION
## ✅ ISSUE 번호

## ✅ 작업 내용
![image](https://github.com/user-attachments/assets/1c98279f-1b6d-4533-a8e8-2e5a0fa4649f)
![image](https://github.com/user-attachments/assets/eba6dd11-de37-4c6f-8334-d7fbab5c6f76)
url로 받아온 planId 로 DB에서 활동리스트 조회하여 출력하도록 작업했습니다. 


## ✅ 리뷰 요청사항

수정 페이지 http://localhost:5173/plans/9e74d62c-3954-41ab-9aca-780c16a61f0d