### PR TITLE
[FEAT] (FE) 활동 리스트 DB에서 불러오기 및 단일활동 삭제 

### DIFF
--- a/frontend/src/api/Days.ts
+++ b/frontend/src/api/Days.ts
@@ -1,0 +1,32 @@
+import axios from 'axios'
+
+import { Activity, Day, DaysResDto } from '@/types/plan'
+
+export const fetchDays = async (): Promise<Day[]> => {
+  const planId = '9e74d62c-3954-41ab-9aca-780c16a61f0d'
+  try {
+    const response = await axios.get<DaysResDto>(
+      `http://localhost:3333/plans/${planId}/all`
+    )
+
+    const convertData: Day[] = response.data.map((day: Day) => {
+      const temp: Activity[] = day.activities.map((activity) => ({
+        id: activity.id,
+        isActivity: activity.isActivity,
+        order: activity.order,
+        category: activity.category,
+        activityName: activity.activity_name, // CamelCase로 변환된 이름
+        activityLocation: activity.activity_location, // CamelCase로 변환된 이름
+        detail: activity.detail,
+        activityExpenses: activity.activity_expenses,
+      }))
+
+      return { ...day, activities: temp }
+    })
+
+    return convertData
+  } catch (error) {
+    console.error('Error fetching plans:', error)
+    return []
+  }
+}

--- a/frontend/src/api/Days.ts
+++ b/frontend/src/api/Days.ts
@@ -2,11 +2,14 @@ import axios from 'axios'
 
 import { Activity, Day, DaysResDto } from '@/types/plan'
 
+const BASE_URL: string =
+  import.meta.env.VITE_BE_BASE_URL || 'http://localhost:3333'
+
 export const fetchDays = async (planId: string): Promise<Day[]> => {
   // const planId = '9e74d62c-3954-41ab-9aca-780c16a61f0d'
   try {
     const response = await axios.get<DaysResDto>(
-      `http://localhost:3333/plans/${planId}/all`
+      `${BASE_URL}/plans/${planId}/all`
     )
 
     const convertData: Day[] = response.data.map((day: Day) => {
@@ -38,7 +41,7 @@ export const deleteActivity = async (
 ): Promise<void> => {
   try {
     await axios.delete(
-      `http://localhost:3333/plans/${planId}/days/${dayId}/activities/${activityId}`
+      `${BASE_URL}/plans/${planId}/days/${dayId}/activities/${activityId}`
     )
     console.log(`Activity with id ${activityId} deleted successfully.`)
   } catch (error) {

--- a/frontend/src/api/Days.ts
+++ b/frontend/src/api/Days.ts
@@ -2,8 +2,8 @@ import axios from 'axios'
 
 import { Activity, Day, DaysResDto } from '@/types/plan'
 
-export const fetchDays = async (): Promise<Day[]> => {
-  const planId = '9e74d62c-3954-41ab-9aca-780c16a61f0d'
+export const fetchDays = async (planId: string): Promise<Day[]> => {
+  // const planId = '9e74d62c-3954-41ab-9aca-780c16a61f0d'
   try {
     const response = await axios.get<DaysResDto>(
       `http://localhost:3333/plans/${planId}/all`

--- a/frontend/src/api/Days.ts
+++ b/frontend/src/api/Days.ts
@@ -30,3 +30,18 @@ export const fetchDays = async (planId: string): Promise<Day[]> => {
     return []
   }
 }
+
+export const deleteActivity = async (
+  planId: string,
+  dayId: string,
+  activityId: string
+): Promise<void> => {
+  try {
+    await axios.delete(
+      `http://localhost:3333/plans/${planId}/days/${dayId}/activities/${activityId}`
+    )
+    console.log(`Activity with id ${activityId} deleted successfully.`)
+  } catch (error) {
+    console.error('Error deleting activity:', error)
+  }
+}

--- a/frontend/src/components/planDetail/DaySection.tsx
+++ b/frontend/src/components/planDetail/DaySection.tsx
@@ -58,7 +58,7 @@ function DaySection({ day, dayIndex, country }: Props) {
           />
         )}
         {currentTab === DaysTabEnum.Activity && (
-          <ActivityList activities={activities} />
+          <ActivityList activities={activities} dayId={id} />
         )}
         {currentTab === DaysTabEnum.Expense && <ExpenseTable />}
       </div>

--- a/frontend/src/components/planDetail/activity/ActivityItem.tsx
+++ b/frontend/src/components/planDetail/activity/ActivityItem.tsx
@@ -1,6 +1,8 @@
 import { FiEdit3 } from 'react-icons/fi'
 import { RiDeleteBin6Line } from 'react-icons/ri'
+import { useParams } from 'react-router-dom'
 
+import { deleteActivity } from '@/api/Days'
 import { useActivityStore } from '@/store/activity'
 import { Activity, AddActivityReqDto, DaysTabEnum } from '@/types/plan'
 
@@ -9,11 +11,10 @@ import ShowActivity from './ShowActivity'
 
 type Props = {
   activity: Activity
-  editingActivityId: string
-  setEditingActivityId: (id: string) => void
+  dayId: string
 }
 
-function ActivityItem({ activity }: Props) {
+function ActivityItem({ activity, dayId }: Props) {
   const {
     activity: editingItem,
     editingActivityId,
@@ -35,6 +36,13 @@ function ActivityItem({ activity }: Props) {
   const handleCancelClick = () => {
     setEditingActivityId('')
   }
+  const { id: planId } = useParams<string>()
+  const handleDeleteClick = () => {
+    if (planId) {
+      deleteActivity(planId, dayId, activity.id)
+      console.log('delete' + planId)
+    }
+  }
 
   return (
     <div className="text-s mb-3 max-w-md rounded-lg bg-gray-50 p-4 shadow-container">
@@ -42,7 +50,9 @@ function ActivityItem({ activity }: Props) {
         <button onClick={handleEditClick}>
           <FiEdit3 />
         </button>
-        <RiDeleteBin6Line />
+        <button onClick={handleDeleteClick}>
+          <RiDeleteBin6Line />
+        </button>
       </div>
 
       {editingActivityId === activity.id ? (

--- a/frontend/src/components/planDetail/activity/ActivityList.tsx
+++ b/frontend/src/components/planDetail/activity/ActivityList.tsx
@@ -6,15 +6,17 @@ import ActivityItem from './ActivityItem'
 
 type Props = {
   activities: Activity[]
+  dayId: string
 }
 
-function ActivityList({ activities }: Props) {
+function ActivityList({ activities, dayId }: Props) {
   const [editingActivityId, setEditingActivityId] = useState('')
   return (
     <div className="text-sm">
       {activities.map((activity) => (
         <ActivityItem
           key={activity.id}
+          dayId={dayId}
           activity={activity}
           editingActivityId={editingActivityId}
           setEditingActivityId={setEditingActivityId}

--- a/frontend/src/components/planDetail/activity/ActivityList.tsx
+++ b/frontend/src/components/planDetail/activity/ActivityList.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react'
-
 import { Activity } from '@/types/plan'
 
 import ActivityItem from './ActivityItem'
@@ -10,17 +8,10 @@ type Props = {
 }
 
 function ActivityList({ activities, dayId }: Props) {
-  const [editingActivityId, setEditingActivityId] = useState('')
   return (
     <div className="text-sm">
       {activities.map((activity) => (
-        <ActivityItem
-          key={activity.id}
-          dayId={dayId}
-          activity={activity}
-          editingActivityId={editingActivityId}
-          setEditingActivityId={setEditingActivityId}
-        />
+        <ActivityItem key={activity.id} dayId={dayId} activity={activity} />
       ))}
     </div>
   )

--- a/frontend/src/pages/PlanDetailPage.tsx
+++ b/frontend/src/pages/PlanDetailPage.tsx
@@ -1,9 +1,24 @@
+import { useEffect, useState } from 'react'
+
+import { fetchDays } from '@/api/Days'
 import DaySection from '@/components/planDetail/DaySection'
 import { dummyDays, dummyPlan } from '@/constants'
+import { Day } from '@/types/plan'
 
 function PlanDetailPage() {
   // TODO: get plan by id api call
   const { planName, planCountry, totalExpenses } = dummyPlan
+  const [days, setDays] = useState<Day[]>([])
+
+  useEffect(() => {
+    const getDays = async () => {
+      const data = await fetchDays()
+
+      setDays(data)
+    }
+
+    getDays()
+  }, [])
   // TODO: get activity list api call
 
   return (
@@ -17,7 +32,7 @@ function PlanDetailPage() {
       </div>
 
       <div className="flex flex-col gap-y-4">
-        {dummyDays.map((day, index) => (
+        {days.map((day, index) => (
           <DaySection
             key={day.id}
             day={day}

--- a/frontend/src/pages/PlanDetailPage.tsx
+++ b/frontend/src/pages/PlanDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
 
 import { fetchDays } from '@/api/Days'
 import DaySection from '@/components/planDetail/DaySection'
@@ -8,18 +9,20 @@ import { Day } from '@/types/plan'
 function PlanDetailPage() {
   // TODO: get plan by id api call
   const { planName, planCountry, totalExpenses } = dummyPlan
+
+  // TODO: get activity list api call
+  const { id: planId } = useParams<string>()
   const [days, setDays] = useState<Day[]>([])
 
   useEffect(() => {
     const getDays = async () => {
-      const data = await fetchDays()
-
-      setDays(data)
+      if (planId) {
+        const data = await fetchDays(planId)
+        setDays(data)
+      }
     }
-
     getDays()
   }, [])
-  // TODO: get activity list api call
 
   return (
     <div className="relative flex w-full flex-col gap-y-4 px-3 py-2 pb-4">


### PR DESCRIPTION
## ✅ ISSUE 번호

## ✅ 작업 내용
![image](https://github.com/user-attachments/assets/1c98279f-1b6d-4533-a8e8-2e5a0fa4649f)
![image](https://github.com/user-attachments/assets/eba6dd11-de37-4c6f-8334-d7fbab5c6f76)
- url로 받아온 planId 로 DB에서 활동리스트 조회하여 출력하도록 작업했습니다. 

![image](https://github.com/user-attachments/assets/b9818b3a-5981-4d61-be5a-731ba78be43f)
![image](https://github.com/user-attachments/assets/99b80801-f14e-4a52-957f-0f2a0ea20cc6)
- 단일 활동의 우측 상단 삭제 버튼을 누르면 서버로 delete 요청을 보내고, 단일 활동이 삭제됩니다. 
- 새로고침을 해야 다시 렌더링이 돼서 이 부분 수정이 필요합니다. 
- 삭제 요청을 보낼 때 planId, dayId, activityId가 필요해서,
  -  planId는 url 에서 받아오고, 
  - dayId는 DaySection에서 props로 내려주고, 
  - activityId는 props로 받아온 activity에서 꺼내와서 서버에 delete 요청을 보내도록 작업하였습니다. 
## ✅ 리뷰 요청사항
