### PR TITLE
[FEAT] (FE) 경비 인풋 ui, 환율 api 연동

### DIFF
--- a/frontend/src/api/plans.ts
+++ b/frontend/src/api/plans.ts
@@ -7,6 +7,9 @@ import {
   AddEtcActivityResDto,
   AddPlanReqDto,
   AddPlanResDto,
+  ConvertCurrencyReqDto,
+  ConvertCurrencyResDto,
+  CountryCodeResDto,
   PlacesResDto,
   PlanResDto,
 } from '@/types/plan'
@@ -133,6 +136,32 @@ export const plansApi = {
       return { data, status }
     } catch (error) {
       console.error('Add expense activity request failed', error)
+    }
+  },
+  getCountryCode: async (planId: string) => {
+    try {
+      const { data, status } = await axiosRequestHandler<CountryCodeResDto>({
+        method: 'get',
+        url: `/api/plans/${planId}/currency`,
+      })
+
+      return { data, status }
+    } catch (error) {
+      console.error('Get country code request failed', error)
+    }
+  },
+  convertCurrency: async ({ from, to, amount }: ConvertCurrencyReqDto) => {
+    try {
+      const { data, status } = await axiosRequestHandler<ConvertCurrencyResDto>(
+        {
+          method: 'get',
+          url: `/api/currency?from=${from}&to=${to}&amount=${amount}`,
+        }
+      )
+
+      return { data, status }
+    } catch (error) {
+      console.error('Convert currency requeset failed', error)
     }
   },
 }

--- a/frontend/src/components/planDetail/DaySection.tsx
+++ b/frontend/src/components/planDetail/DaySection.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import { plansApi } from '@/api/plans'
+import { useModal } from '@/hooks/useModal'
 import { usePending } from '@/hooks/usePending'
 import { HttpStatusCodeEnum } from '@/types'
 import { Activity, AddActivityReqDto, Day, DaysTabEnum } from '@/types/plan'
@@ -23,19 +24,17 @@ function DaySection({ planId, day, dayIndex, country }: Props) {
   const [currentTab, setCurrentTab] = useState<DaysTabEnum>(
     DaysTabEnum.Activity
   )
-  const [showForm, setShowForm] = useState<boolean>(false)
+  const {
+    isModalOpen: showForm,
+    openModal: openForm,
+    closeModal: closeForm,
+  } = useModal()
   const [activitiesByDay, setActivitiesByDay] = useState<Activity[]>(activities)
   const { isPending, toggleIsPending } = usePending()
 
   const changeCurrentTab = (tab: DaysTabEnum) => {
     setCurrentTab(tab)
-    setShowForm(false)
-  }
-  const openForm = () => {
-    setShowForm(true)
-  }
-  const closeForm = () => {
-    setShowForm(false)
+    closeForm()
   }
   const addActivity = async (payload: AddActivityReqDto) => {
     toggleIsPending(true)

--- a/frontend/src/components/planDetail/activity/ActivityForm.tsx
+++ b/frontend/src/components/planDetail/activity/ActivityForm.tsx
@@ -106,7 +106,7 @@ function ActivityForm({
         name="경비"
         value={
           <ExpenseInput
-            value={activityPayload.activityExpenses?.toString()}
+            value={activityPayload.activityExpenses || ''}
             onChange={(e) =>
               updatePayload({ activityExpenses: Number(e.target.value) })
             }

--- a/frontend/src/components/planDetail/activity/ExpenseInput.tsx
+++ b/frontend/src/components/planDetail/activity/ExpenseInput.tsx
@@ -1,10 +1,63 @@
-import { Input } from '@/components/common'
+import { InputHTMLAttributes, useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
 
-function ExpenseInput() {
+import { plansApi } from '@/api/plans'
+import { Input } from '@/components/common'
+import { DateFormatTypeEnum, HttpStatusCodeEnum } from '@/types'
+import { Currency } from '@/types/plan'
+import { formatDate } from '@/utils/formatDate'
+
+type Props = InputHTMLAttributes<HTMLInputElement>
+
+const KRW = 'KRW'
+
+function ExpenseInput({ type, value, onChange, onBlur, ...props }: Props) {
+  const { planId } = useParams()
+  const [convertedExpense, setConvertedExpense] = useState<Currency | null>(
+    null
+  )
+  const [countryCode, setCountryCode] = useState<string>('')
+
+  const convertCurrency = async () => {
+    const response = await plansApi.convertCurrency({
+      from: KRW,
+      to: countryCode,
+      amount: Number(value),
+    })
+
+    if (response?.status === HttpStatusCodeEnum.OK) {
+      setConvertedExpense(response.data.converted)
+    }
+  }
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const response = await plansApi.getCountryCode(planId || '')
+
+      if (response?.status === HttpStatusCodeEnum.OK) {
+        setCountryCode(response.data)
+      }
+    }
+
+    fetchData()
+  }, [])
+
   return (
     <div className="flex flex-col gap-y-2">
-      <Input className="p-2" />
-      {/* 환율 */}
+      <Input
+        value={value}
+        onChange={onChange}
+        className="p-2 text-sm"
+        type="text"
+        onBlur={convertCurrency}
+        {...props}
+      />
+      <p className="mr-2 text-right text-sm text-gray-500">
+        {formatDate(DateFormatTypeEnum.DateWithDots, new Date())} 기준{' '}
+        &nbsp;&nbsp;&nbsp;
+        {countryCode} &nbsp;
+        {convertedExpense?.value.toFixed(1).toLocaleString() || '-'}
+      </p>
     </div>
   )
 }

--- a/frontend/src/types/plan.ts
+++ b/frontend/src/types/plan.ts
@@ -59,6 +59,11 @@ export type ActivitiesByPlan = {
   activities: Activity[]
 }
 
+export type Currency = {
+  code: string
+  value: number
+}
+
 export type AddPlanReqDto = Omit<Plan, 'id' | 'totalExpenses'>
 
 export type AddPlanResDto = Plan
@@ -96,3 +101,16 @@ export type OrderActivitiesResDto = {
 }
 
 export type PlacesResDto = Place[]
+
+export type CountryCodeResDto = string
+
+export type ConvertCurrencyReqDto = {
+  from: string
+  to: string
+  amount: number
+}
+
+export type ConvertCurrencyResDto = {
+  original: Currency
+  converted: Currency
+}


### PR DESCRIPTION
## ✅ ISSUE 번호

## ✅ 작업 내용
<img width="460" alt="스크린샷 2024-08-25 오후 5 39 26" src="https://github.com/user-attachments/assets/84d319e4-48e8-4c7e-9ef1-3dddb18baf84">

- url: `/plans/:planId`
- 활동 폼 내 경비 인풋
   - ui 작업
   - 환율 변환 api 연동: 환율 변환 api는 `onBlur` 시 콜합니다.

## ✅ 리뷰 요청사항
