### PR TITLE
[FEAT] 장소 -> 장소, 주소 로 변경

### DIFF
--- a/frontend/src/components/planDetail/activity/ShowActivity.tsx
+++ b/frontend/src/components/planDetail/activity/ShowActivity.tsx
@@ -13,7 +13,8 @@ function ShowActivity({ activity }: Props) {
   const categoryColor = dayCategories.find(
     (category) => category.name === activity.category
   )?.color
-
+  const [placeName, roadAddressName] =
+    activity.activityLocation?.split('/') || []
   const style = 'inline-block min-w-20 text-nowrap text-sm text-gray-500'
 
   return (
@@ -34,7 +35,11 @@ function ShowActivity({ activity }: Props) {
       </div>
       <div className="mb-3 flex">
         <div className={style}>장소</div>
-        <div>{activity.activityLocation}</div>
+        <div>{placeName}</div>
+      </div>
+      <div className="mb-3 flex">
+        <div className={style}>주소</div>
+        <div>{roadAddressName}</div>
       </div>
       <div className="mb-3 flex">
         <div className={style}>메모</div>

--- a/frontend/src/components/planDetail/activity/ShowActivity.tsx
+++ b/frontend/src/components/planDetail/activity/ShowActivity.tsx
@@ -33,22 +33,54 @@ function ShowActivity({ activity }: Props) {
         <div className={style}>활동명</div>
         <div>{activity.activityName}</div>
       </div>
-      <div className="mb-3 flex">
+      {placeName ? (
+        <div className="mb-3 flex">
+          <div className={style}>장소</div>
+          <div>{placeName}</div>
+        </div>
+      ) : (
+        <></>
+      )}
+      {roadAddressName ? (
+        <div className="mb-3 flex">
+          <div className={style}>주소</div>
+          <div>{roadAddressName}</div>
+        </div>
+      ) : (
+        <></>
+      )}
+      {activity.detail ? (
+        <div className="mb-3 flex">
+          <div className={style}>메모</div>
+          <div>{activity.detail}</div>
+        </div>
+      ) : (
+        <></>
+      )}
+      {activity.activityExpenses ? (
+        <div className="flex">
+          <div className={style}>경비</div>
+          <div>{activity.activityExpenses}</div>
+        </div>
+      ) : (
+        <></>
+      )}
+      {/* <div className="mb-3 flex">
         <div className={style}>장소</div>
-        <div>{placeName}</div>
+        <div>{placeName || '-'}</div>
       </div>
       <div className="mb-3 flex">
         <div className={style}>주소</div>
-        <div>{roadAddressName}</div>
+        <div>{roadAddressName || '-'}</div>
       </div>
       <div className="mb-3 flex">
         <div className={style}>메모</div>
-        <div>{activity.detail}</div>
+        <div>{activity.detail || ''}</div>
       </div>
       <div className="flex">
         <div className={style}>경비</div>
-        <div>{activity.activityExpenses}</div>
-      </div>
+        <div>{activity.activityExpenses || '-'}</div>
+      </div> */}
     </div>
   )
 }

--- a/frontend/src/components/planDetail/activity/ShowActivity.tsx
+++ b/frontend/src/components/planDetail/activity/ShowActivity.tsx
@@ -33,7 +33,7 @@ function ShowActivity({ activity }: Props) {
         <div className={style}>활동명</div>
         <div>{activity.activityName}</div>
       </div>
-      {placeName ? (
+      {/* {placeName ? (
         <div className="mb-3 flex">
           <div className={style}>장소</div>
           <div>{placeName}</div>
@@ -64,8 +64,8 @@ function ShowActivity({ activity }: Props) {
         </div>
       ) : (
         <></>
-      )}
-      {/* <div className="mb-3 flex">
+      )} */}
+      <div className="mb-3 flex">
         <div className={style}>장소</div>
         <div>{placeName || '-'}</div>
       </div>
@@ -80,7 +80,7 @@ function ShowActivity({ activity }: Props) {
       <div className="flex">
         <div className={style}>경비</div>
         <div>{activity.activityExpenses || '-'}</div>
-      </div> */}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## ✅ ISSUE 번호

## ✅ 작업 내용
![image](https://github.com/user-attachments/assets/c6f64843-d69d-4e89-9683-8d8c1555245a)
- 카카오 api 장소 검색 적용을 위해 장소 출력 형식을 변경했습니다. 
![image](https://github.com/user-attachments/assets/aade2c76-4640-4e90-9a9d-4bd31ffba17d)
- DB에는 ```activity_location```에 '/'를 기준으로 ```{placeName/roadAddressName}``` ```장소명/도로명주소```가 저장되며, 페이지에서 렌더링 할 때는 ```split('/')``` 으로 각 값을 분리하여 출력합니다. 
## ✅ 리뷰 요청사항
