### PR TITLE
[REFACTOR] (BE) 일정/경비 탭 조회 api 수정

### DIFF
--- a/backend/src/modules/activity/activity.controller.ts
+++ b/backend/src/modules/activity/activity.controller.ts
@@ -21,20 +21,27 @@ export class ActivityController {
   findAll(
     @Param('planId') planId: string,
     @Param('dayId') dayId: string,
-    @Query('isActivity') isActivity?: string,
     @Query('category') category?: string,
   ) {
-    // isActivity가 제공된 경우 문자열을 boolean으로 변환, 제공되지 않으면 undefined
-    const isActivityBoolean =
-      isActivity === 'true' ? true : isActivity === 'false' ? false : undefined;
+    return this.activityService.findAll(planId, dayId, category);
+  }
 
-    // 쿼리 파라미터에 따른 활동 조회
-    return this.activityService.findAll(
-      planId,
-      dayId,
-      isActivityBoolean,
-      category,
-    );
+  // 일정 탭 조회
+  @Get('isActivity')
+  findActivities(
+    @Param('planId') planId: string,
+    @Param('dayId') dayId: string,
+  ) {
+    return this.activityService.findActivitiesByIsActivity(planId, dayId, true);
+  }
+
+  // 경비 탭 조회
+  @Get('expenses')
+  findActivitiesWithExpenses(
+    @Param('planId') planId: string,
+    @Param('dayId') dayId: string,
+  ) {
+    return this.activityService.findActivitiesWithExpenses(planId, dayId);
   }
 
   // 단일 조회


### PR DESCRIPTION
## ✅ ISSUE 번호
#96 

## ✅ 작업 내용
- 일정 탭 조회 findActivitiesByIsActivity API 로 수정
- 엔드포인트 `api/plans/:planId/days/:dayId/activities/isActivity` 로 변경
- 경비 탭 조회 findActivitiesWithExpenses API 로 수정
- 엔드포인트 `api/plans/:planId/days/:dayId/activities/expenses`로 변경

## ✅ 리뷰 요청사항
