### PR TITLE
[FEAT] (FE) 활동(일정) 수정, 삭제 시 로딩 스피너 추가

### DIFF
--- a/frontend/src/components/planDetail/activity/ShowActivity.tsx
+++ b/frontend/src/components/planDetail/activity/ShowActivity.tsx
@@ -75,7 +75,7 @@ function ShowActivity({ activity }: Props) {
       </div>
       <div className="mb-3 flex">
         <div className={style}>메모</div>
-        <div>{activity.detail || ''}</div>
+        <div>{activity.detail || '-'}</div>
       </div>
       <div className="flex">
         <div className={style}>경비</div>


### PR DESCRIPTION
## ✅ ISSUE 번호

## ✅ 작업 내용
![image](https://github.com/user-attachments/assets/30cc12c9-a004-42d8-b924-f92970d3c4c7)
![image](https://github.com/user-attachments/assets/828ced43-c53a-4c3b-a5e0-a095c901ad40)
- 활동(일정) 수정 및 삭제 시에 로딩 스피너 돌아가도록 작업하였습니다. 

## ✅ 리뷰 요청사항
