### PR TITLE
[STYLE] (FE) 수정 모드일 때 Acticivy Form css 변경

### DIFF
--- a/frontend/src/components/planDetail/activity/ActivityForm.tsx
+++ b/frontend/src/components/planDetail/activity/ActivityForm.tsx
@@ -12,6 +12,7 @@ import LocationInput from './LocationInput'
 type Props = {
   currentTab: DaysTabEnum
   defaultValues?: AddActivityReqDto
+  isEditMode?: boolean
   isLoading?: boolean
   handleCancel: () => void
   handleSave: (payload: AddActivityReqDto) => void
@@ -29,6 +30,7 @@ function ActivityForm({
   currentTab,
   defaultValues,
   isLoading,
+  isEditMode,
   handleCancel,
   handleSave,
 }: Props) {
@@ -58,7 +60,7 @@ function ActivityForm({
   }
 
   return (
-    <form className="rounded-md border border-gray-300 p-4">
+    <form className={isEditMode ? '' : 'rounded-md border border-gray-300 p-4'}>
       <Field
         name="카테고리"
         value={

--- a/frontend/src/components/planDetail/activity/ActivityItem.tsx
+++ b/frontend/src/components/planDetail/activity/ActivityItem.tsx
@@ -95,9 +95,10 @@ function ActivityItem({ activity, planId, dayId, setActivitiesByDay }: Props) {
 
       {editingActivityId === activity.id ? (
         <ActivityForm
-          isLoading={isPending}
           currentTab={DaysTabEnum.Activity}
           defaultValues={editingItem}
+          isEditMode={true}
+          isLoading={isPending}
           handleCancel={handleCancelClick}
           handleSave={handleSaveClick}
         />


### PR DESCRIPTION
## ✅ ISSUE 번호

## ✅ 작업 내용
![image](https://github.com/user-attachments/assets/8bb88f84-8ce4-4ab7-a0c7-4e6614750cfb)
- ActivityForm 에 optional props로 isEditMode 를 추가하여 수정 모드일 때 ActivityForm의 border 제거하였습니다. 

## ✅ 리뷰 요청사항
